### PR TITLE
Add scaffolding for page cache component

### DIFF
--- a/backend/page-cache/function.py
+++ b/backend/page-cache/function.py
@@ -1,0 +1,20 @@
+import functions_framework
+from flask import Request, typing
+
+
+@functions_framework.http
+def page_cache(request: Request) -> typing.ResponseReturnValue:
+    """
+    Check if the submitted document has already been analyzed.
+
+    :param request: the incoming request
+    :return: whether the document has already been analyzed
+    """
+
+    # TODO: validate incoming request
+    # TODO: compute the hash of the document
+    # TODO: check if the hash is in the cache
+    # TODO: if in cache, return document ID
+    # TODO: if not in cache, return False
+
+    return {"cached": False}

--- a/backend/page-cache/pyproject.toml
+++ b/backend/page-cache/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "page_cache"
+version = "1.0.0"
+
+requires-python = ">=3.10"
+
+dependencies = ["functions-framework>=3.5.0"]
+
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:3c0b0b4aa014d1d0c4ead3ae1c7a1e7373aeb7022c87e06bab1d6e4ac0db83fa"
+content_hash = "sha256:ecc833eb392e1df2c9dbcb9e43cf934a8f8bb7db15c94b9fcbfc9ee4aa8977fa"
 
 [[package]]
 name = "analysis-manager"
@@ -207,6 +207,18 @@ groups = ["dev"]
 files = [
     {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
     {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
+]
+
+[[package]]
+name = "page-cache"
+version = "1.0.0"
+requires_python = ">=3.10"
+editable = true
+path = "./backend/page-cache"
+summary = ""
+groups = ["dev"]
+dependencies = [
+    "functions-framework>=3.5.0",
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,11 @@ lint = { cmd = "ruff check" }
 format = { cmd = "ruff format --check" }
 "format:fix" = { cmd = "ruff format" }
 
-analysis-manager = { cmd = "functions-framework --target=analysis_manager --source backend/analysis-manager/function.py" }
-page-cache = { cmd = "functions-framework --target=page_cache --source backend/page-cache/function.py" }
+analysis-manager.cmd = "functions-framework --target=analysis_manager --source backend/analysis-manager/function.py"
+analysis-manager.env = { PORT = "8080" }
+
+page-cache.cmd = "functions-framework --target=page_cache --source backend/page-cache/function.py"
+page-cache.env = { PORT = "8081" }
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,11 @@ dependencies = []
 distribution = false
 
 [tool.pdm.dev-dependencies]
-dev = ["-e analysis_manager @ file:///${PROJECT_ROOT}/backend/analysis-manager", "ruff>=0.4.3"]
+dev = [
+  "-e analysis_manager @ file:///${PROJECT_ROOT}/backend/analysis-manager",
+  "-e page_cache @ file:///${PROJECT_ROOT}/backend/page-cache",
+  "ruff>=0.4.3",
+]
 
 [tool.pdm.scripts]
 lint = { cmd = "ruff check" }
@@ -20,6 +24,7 @@ format = { cmd = "ruff format --check" }
 "format:fix" = { cmd = "ruff format" }
 
 analysis-manager = { cmd = "functions-framework --target=analysis_manager --source backend/analysis-manager/function.py" }
+page-cache = { cmd = "functions-framework --target=page_cache --source backend/page-cache/function.py" }
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
Create the scaffolding for the page cache Cloud Function. For development, it can be run using `pdm page-cache`. To run in development, either add the `--debug` flag or set the `DEBUG` environment variable to 1.

Also ensures that all functions run on separate ports in development. The current mapping is as follows:
- analysis manager -> 8080
- page cache -> 8081