### PR TITLE
Hide python cache and build folders from vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,13 @@
       "source.organizeImports": "always"
     }
   },
-  "eslint.validate": ["javascript", "html"]
+  "eslint.validate": ["javascript", "html"],
+  "files.exclude": {
+    "**/.git": true,
+    "**/.DS_Store": true,
+    "**/Thumbs.db": true,
+    "**/__pycache__": true,
+    "**/.pdm-build": true,
+    "**/*.egg-info": true
+  }
 }


### PR DESCRIPTION
Hides the `__pycache__` and PDM build folders from the VSCode tree view to reduce clutter.