### PR TITLE
Accept request body as JSON for analysis manager

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,8 +8,14 @@
       "name": "analysis-manager",
       "type": "debugpy",
       "request": "launch",
-      "module": "functions_framework",
-      "args": ["--target=handler", "--source=projects/analysis-manager/main.py", "--debug"]
+      "module": "flask",
+      "env": {
+        "FLASK_APP": "development/function.py",
+        "FLASK_DEBUG": "1",
+        "FUNCTION": "analysis_manager"
+      },
+      "args": ["run", "--no-debugger"],
+      "autoStartBrowser": false
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "analysis-manager",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "functions_framework",
+      "args": ["--target=handler", "--source=projects/analysis-manager/main.py", "--debug"]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,8 @@
     "**/.pdm-build": true,
     "**/*.egg-info": true
   },
-  "python.analysis.extraPaths": ["bases", "components"]
+  "python.analysis.extraPaths": ["bases", "components"],
+  "python.testing.pytestArgs": ["test"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/bases/veritasai/analysis_manager/handler.py
+++ b/bases/veritasai/analysis_manager/handler.py
@@ -12,7 +12,7 @@ def handler(request: Request) -> typing.ResponseReturnValue:
     :return: an empty successful response
     """
     try:
-        body = AnalyzeText.model_validate(dict(request.form))
+        body = AnalyzeText.model_validate(request.get_json(silent=True))
     except ValidationError as e:
         return response_from_validation_error(e)
 

--- a/components/veritasai/input_validation/error.py
+++ b/components/veritasai/input_validation/error.py
@@ -9,6 +9,7 @@ def response_from_validation_error(report: ValidationError) -> Response:
     :param report: the validation error
     :return: the response object
     """
-    response = make_response(jsonify(report.errors()))
+    errors = report.errors(include_input=False, include_context=False, include_url=False)
+    response = make_response(jsonify(errors))
     response.status_code = 422
     return response

--- a/development/function.py
+++ b/development/function.py
@@ -1,0 +1,31 @@
+from os import environ
+from pathlib import Path
+
+from functions_framework import create_app
+
+
+def find_project_root_directory() -> Path:
+    """
+    Find the directory containing the project root.
+    """
+    for directory in Path(__file__).parents:
+        try:
+            next(directory.glob("pyproject.toml"))
+            return directory
+        except StopIteration:
+            continue
+
+    raise FileNotFoundError("Could not find the project root directory")
+
+
+FUNCTION = environ.get("FUNCTION")
+if FUNCTION is None or len(FUNCTION) == 0:
+    raise ValueError("The FUNCTION environment variable must be set")
+
+root = find_project_root_directory()
+source = root / "bases" / "veritasai" / FUNCTION / "handler.py"
+
+if not source.exists():
+    raise FileNotFoundError(f"Could not find the function {FUNCTION} at {source}")
+
+app = create_app(source=source, target="handler")

--- a/test/bases/veritasai/analysis_manager/test_validation.py
+++ b/test/bases/veritasai/analysis_manager/test_validation.py
@@ -18,7 +18,7 @@ def data() -> dict[str, str]:
 
 
 def test_missing_fields(client: FlaskClient):
-    response = client.post("/", data={})
+    response = client.post("/", json={})
 
     assert response.status_code == 422
     assert response.json == [
@@ -47,7 +47,7 @@ def test_missing_fields(client: FlaskClient):
 
 def test_all_fields_empty(client: FlaskClient):
     data = {"content": "", "author": "", "publisher": "", "source-url": ""}
-    response = client.post("/", data=data)
+    response = client.post("/", json=data)
 
     assert response.status_code == 422
     assert response.json == [
@@ -76,7 +76,7 @@ def test_all_fields_empty(client: FlaskClient):
 
 def test_content_empty(client: FlaskClient, data: dict[str, str]):
     data["content"] = ""
-    response = client.post("/", data=data)
+    response = client.post("/", json=data)
 
     assert response.status_code == 422
     assert response.json == [
@@ -90,7 +90,7 @@ def test_content_empty(client: FlaskClient, data: dict[str, str]):
 
 def test_author_empty(client: FlaskClient, data: dict[str, str]):
     data["author"] = ""
-    response = client.post("/", data=data)
+    response = client.post("/", json=data)
 
     assert response.status_code == 422
     assert response.json == [
@@ -104,7 +104,7 @@ def test_author_empty(client: FlaskClient, data: dict[str, str]):
 
 def test_publisher_empty(client: FlaskClient, data: dict[str, str]):
     data["publisher"] = ""
-    response = client.post("/", data=data)
+    response = client.post("/", json=data)
 
     assert response.status_code == 422
     assert response.json == [
@@ -118,7 +118,7 @@ def test_publisher_empty(client: FlaskClient, data: dict[str, str]):
 
 def test_url_empty(client: FlaskClient, data: dict[str, str]):
     data["source-url"] = ""
-    response = client.post("/", data=data)
+    response = client.post("/", json=data)
     assert response.status_code == 422
     assert response.json == [
         {
@@ -134,7 +134,7 @@ def test_url_empty(client: FlaskClient, data: dict[str, str]):
 @pytest.mark.parametrize("field,length", [("content", 5), ("author", 2), ("publisher", 5)])
 def test_field_too_short(client: FlaskClient, data: dict[str, str], field: str, length: int):
     data[field] = "a" * (length - 1)
-    response = client.post("/", data=data)
+    response = client.post("/", json=data)
 
     assert response.status_code == 422
     assert response.json == [
@@ -148,7 +148,7 @@ def test_field_too_short(client: FlaskClient, data: dict[str, str], field: str, 
 
 def test_url_invalid_string(client: FlaskClient, data: dict[str, str]):
     data["source-url"] = "Behind ye old windmill"
-    response = client.post("/", data=data)
+    response = client.post("/", json=data)
 
     assert response.status_code == 422
     assert response.json == [
@@ -162,7 +162,7 @@ def test_url_invalid_string(client: FlaskClient, data: dict[str, str]):
 
 def test_url_invalid_domain(client: FlaskClient, data: dict[str, str]):
     data["source-url"] = "http://Behind ye old windmill"
-    response = client.post("/", data=data)
+    response = client.post("/", json=data)
 
     assert response.status_code == 422
     assert response.json == [
@@ -176,7 +176,7 @@ def test_url_invalid_domain(client: FlaskClient, data: dict[str, str]):
 
 def test_url_invalid_characters(client: FlaskClient, data: dict[str, str]):
     data["source-url"] = "ttp://#*@)($#$)"
-    response = client.post("/", data=data)
+    response = client.post("/", json=data)
 
     assert response.status_code == 422
     assert response.json == [

--- a/test/bases/veritasai/analysis_manager/test_validation.py
+++ b/test/bases/veritasai/analysis_manager/test_validation.py
@@ -23,40 +23,24 @@ def test_missing_fields(client: FlaskClient):
     assert response.status_code == 422
     assert response.json == [
         {
-            "input": {},
-            "loc": [
-                "content",
-            ],
+            "loc": ["content"],
             "msg": "Field required",
             "type": "missing",
-            "url": "https://errors.pydantic.dev/2.7/v/missing",
         },
         {
-            "input": {},
-            "loc": [
-                "author",
-            ],
+            "loc": ["author"],
             "msg": "Field required",
             "type": "missing",
-            "url": "https://errors.pydantic.dev/2.7/v/missing",
         },
         {
-            "input": {},
-            "loc": [
-                "publisher",
-            ],
+            "loc": ["publisher"],
             "msg": "Field required",
             "type": "missing",
-            "url": "https://errors.pydantic.dev/2.7/v/missing",
         },
         {
-            "input": {},
-            "loc": [
-                "source-url",
-            ],
+            "loc": ["source-url"],
             "msg": "Field required",
             "type": "missing",
-            "url": "https://errors.pydantic.dev/2.7/v/missing",
         },
     ]
 
@@ -68,52 +52,24 @@ def test_all_fields_empty(client: FlaskClient):
     assert response.status_code == 422
     assert response.json == [
         {
-            "ctx": {
-                "min_length": 5,
-            },
-            "input": "",
-            "loc": [
-                "content",
-            ],
+            "loc": ["content"],
             "msg": "String should have at least 5 characters",
             "type": "string_too_short",
-            "url": "https://errors.pydantic.dev/2.7/v/string_too_short",
         },
         {
-            "ctx": {
-                "min_length": 2,
-            },
-            "input": "",
-            "loc": [
-                "author",
-            ],
+            "loc": ["author"],
             "msg": "String should have at least 2 characters",
             "type": "string_too_short",
-            "url": "https://errors.pydantic.dev/2.7/v/string_too_short",
         },
         {
-            "ctx": {
-                "min_length": 5,
-            },
-            "input": "",
-            "loc": [
-                "publisher",
-            ],
+            "loc": ["publisher"],
             "msg": "String should have at least 5 characters",
             "type": "string_too_short",
-            "url": "https://errors.pydantic.dev/2.7/v/string_too_short",
         },
         {
-            "ctx": {
-                "error": "input is empty",
-            },
-            "input": "",
-            "loc": [
-                "source-url",
-            ],
+            "loc": ["source-url"],
             "msg": "Input should be a valid URL, input is empty",
             "type": "url_parsing",
-            "url": "https://errors.pydantic.dev/2.7/v/url_parsing",
         },
     ]
 
@@ -125,16 +81,9 @@ def test_content_empty(client: FlaskClient, data: dict[str, str]):
     assert response.status_code == 422
     assert response.json == [
         {
-            "ctx": {
-                "min_length": 5,
-            },
-            "input": "",
-            "loc": [
-                "content",
-            ],
+            "loc": ["content"],
             "msg": "String should have at least 5 characters",
             "type": "string_too_short",
-            "url": "https://errors.pydantic.dev/2.7/v/string_too_short",
         },
     ]
 
@@ -146,16 +95,9 @@ def test_author_empty(client: FlaskClient, data: dict[str, str]):
     assert response.status_code == 422
     assert response.json == [
         {
-            "ctx": {
-                "min_length": 2,
-            },
-            "input": "",
-            "loc": [
-                "author",
-            ],
+            "loc": ["author"],
             "msg": "String should have at least 2 characters",
             "type": "string_too_short",
-            "url": "https://errors.pydantic.dev/2.7/v/string_too_short",
         },
     ]
 
@@ -167,41 +109,24 @@ def test_publisher_empty(client: FlaskClient, data: dict[str, str]):
     assert response.status_code == 422
     assert response.json == [
         {
-            "ctx": {
-                "min_length": 5,
-            },
-            "input": "",
             "loc": ["publisher"],
             "msg": "String should have at least 5 characters",
             "type": "string_too_short",
-            "url": "https://errors.pydantic.dev/2.7/v/string_too_short",
         },
     ]
 
 
-def test_url_empty(client: FlaskClient):
-    response = client.post(
-        "/",
-        data={
-            "content": "Yesterday's news tomorrow, Tonight at 5.",
-            "author": "Guy Fawkes",
-            "publisher": "Fawkes News",
-            "source-url": "",
-        },
-    )
+def test_url_empty(client: FlaskClient, data: dict[str, str]):
+    data["source-url"] = ""
+    response = client.post("/", data=data)
     assert response.status_code == 422
     assert response.json == [
         {
-            "ctx": {
-                "error": "input is empty",
-            },
-            "input": "",
             "loc": [
                 "source-url",
             ],
             "msg": "Input should be a valid URL, input is empty",
             "type": "url_parsing",
-            "url": "https://errors.pydantic.dev/2.7/v/url_parsing",
         },
     ]
 
@@ -214,14 +139,9 @@ def test_field_too_short(client: FlaskClient, data: dict[str, str], field: str, 
     assert response.status_code == 422
     assert response.json == [
         {
-            "ctx": {
-                "min_length": length,
-            },
-            "input": "a" * (length - 1),
             "loc": [field],
             "msg": f"String should have at least {length} characters",
             "type": "string_too_short",
-            "url": "https://errors.pydantic.dev/2.7/v/string_too_short",
         },
     ]
 
@@ -233,16 +153,9 @@ def test_url_invalid_string(client: FlaskClient, data: dict[str, str]):
     assert response.status_code == 422
     assert response.json == [
         {
-            "ctx": {
-                "error": "relative URL without a base",
-            },
-            "input": "Behind ye old windmill",
-            "loc": [
-                "source-url",
-            ],
+            "loc": ["source-url"],
             "msg": "Input should be a valid URL, relative URL without a base",
             "type": "url_parsing",
-            "url": "https://errors.pydantic.dev/2.7/v/url_parsing",
         },
     ]
 
@@ -254,16 +167,9 @@ def test_url_invalid_domain(client: FlaskClient, data: dict[str, str]):
     assert response.status_code == 422
     assert response.json == [
         {
-            "ctx": {
-                "error": "invalid domain character",
-            },
-            "input": "http://Behind ye old windmill",
-            "loc": [
-                "source-url",
-            ],
+            "loc": ["source-url"],
             "msg": "Input should be a valid URL, invalid domain character",
             "type": "url_parsing",
-            "url": "https://errors.pydantic.dev/2.7/v/url_parsing",
         },
     ]
 
@@ -275,15 +181,8 @@ def test_url_invalid_characters(client: FlaskClient, data: dict[str, str]):
     assert response.status_code == 422
     assert response.json == [
         {
-            "ctx": {
-                "expected_schemes": "'http' or 'https'",
-            },
-            "input": "ttp://#*@)($#$)",
-            "loc": [
-                "source-url",
-            ],
+            "loc": ["source-url"],
             "msg": "URL scheme should be 'http' or 'https'",
             "type": "url_scheme",
-            "url": "https://errors.pydantic.dev/2.7/v/url_scheme",
         },
     ]


### PR DESCRIPTION
Make the analysis manager accept it's requests as JSON instead of form body. This is easier for us to handle and is likely how the frontend will send data. We likely cannot use a form to send the data since we'll need to add the firebase ID token along with the request as a header.

Also integrates pytest and the handler functions with the VSCode launch system for better debugging.