### PR TITLE
Generate document id from input in analysis manager

### DIFF
--- a/bases/veritasai/analysis_manager/handler.py
+++ b/bases/veritasai/analysis_manager/handler.py
@@ -1,5 +1,6 @@
 import functions_framework
 from flask import Request, typing
+from veritasai import document_id
 from veritasai.input_validation import AnalyzeText, ValidationError, response_from_validation_error
 
 
@@ -17,6 +18,9 @@ def handler(request: Request) -> typing.ResponseReturnValue:
         return response_from_validation_error(e)
 
     print(body)
+
+    unique_id = document_id.generate(body.content, body.author, body.publisher)
+    print(unique_id)
 
     # TODO: check if the document has already been processed
     # TODO: (maybe) save the document to a storage bucket

--- a/components/veritasai/input_validation/models.py
+++ b/components/veritasai/input_validation/models.py
@@ -9,6 +9,6 @@ class AnalyzeText(BaseModel):
     model_config = ConfigDict(alias_generator=lambda name: name.replace("_", "-"))
 
     content: str = Field(min_length=5)
-    author: str = Field(min_length=2)
-    publisher: str = Field(min_length=5)
-    source_url: HttpUrl
+    author: str | None = Field(default=None, min_length=2)
+    publisher: str | None = Field(default=None, min_length=5)
+    source_url: HttpUrl | None = None

--- a/test/bases/veritasai/analysis_manager/test_validation.py
+++ b/test/bases/veritasai/analysis_manager/test_validation.py
@@ -27,21 +27,6 @@ def test_missing_fields(client: FlaskClient):
             "msg": "Field required",
             "type": "missing",
         },
-        {
-            "loc": ["author"],
-            "msg": "Field required",
-            "type": "missing",
-        },
-        {
-            "loc": ["publisher"],
-            "msg": "Field required",
-            "type": "missing",
-        },
-        {
-            "loc": ["source-url"],
-            "msg": "Field required",
-            "type": "missing",
-        },
     ]
 
 

--- a/test/components/veritasai/input_validation/test_analyze_text.py
+++ b/test/components/veritasai/input_validation/test_analyze_text.py
@@ -36,27 +36,6 @@ def test_missing_fields():
             "type": "missing",
             "url": "https://errors.pydantic.dev/2.7/v/missing",
         },
-        {
-            "input": {},
-            "loc": ("author",),
-            "msg": "Field required",
-            "type": "missing",
-            "url": "https://errors.pydantic.dev/2.7/v/missing",
-        },
-        {
-            "input": {},
-            "loc": ("publisher",),
-            "msg": "Field required",
-            "type": "missing",
-            "url": "https://errors.pydantic.dev/2.7/v/missing",
-        },
-        {
-            "input": {},
-            "loc": ("source-url",),
-            "msg": "Field required",
-            "type": "missing",
-            "url": "https://errors.pydantic.dev/2.7/v/missing",
-        },
     ]
 
 


### PR DESCRIPTION
Generates the document ID using the shared `document_id` package from validated input in the analysis manager. The author, publisher, and source_url fields in the HTTP body are now allowed to be optional, in accordance with the UI requirements.