### PR TITLE
Fix import of document id generation

### DIFF
--- a/bases/veritasai/analysis_manager/handler.py
+++ b/bases/veritasai/analysis_manager/handler.py
@@ -1,6 +1,6 @@
 import functions_framework
 from flask import Request, typing
-from veritasai import document_id
+from veritasai.document_id import generate_id
 from veritasai.input_validation import AnalyzeText, ValidationError, response_from_validation_error
 
 
@@ -19,7 +19,7 @@ def handler(request: Request) -> typing.ResponseReturnValue:
 
     print(body)
 
-    unique_id = document_id.generate(body.content, body.author, body.publisher)
+    unique_id = generate_id(body.content, body.author, body.publisher)
     print(unique_id)
 
     # TODO: check if the document has already been processed

--- a/components/veritasai/document_id/__init__.py
+++ b/components/veritasai/document_id/__init__.py
@@ -2,7 +2,7 @@ from base64 import urlsafe_b64encode
 from hashlib import sha3_256
 
 
-def generate(content: str, author: str | None = None, source: str | None = None) -> str:
+def generate_id(content: str, author: str | None = None, source: str | None = None) -> str:
     """
     Generate a document ID from the content, author and source.
 

--- a/test/components/veritasai/document_id/test_generate.py
+++ b/test/components/veritasai/document_id/test_generate.py
@@ -1,68 +1,68 @@
-from veritasai.document_id import generate
+from veritasai.document_id import generate_id
 
 
 def test_empty_content():
-    result = generate("")
+    result = generate_id("")
     assert result == "7uL4nSE_CEOnSJufwAJYzR2I3JULGmDbEiaOi82Qch8="
 
 
 def test_content_only():
-    result = generate("Hello, world!")
+    result = generate_id("Hello, world!")
     assert result == "O4zSymKk7nPkQPdq3VRRHlXho0-HbQe0YU1rEIUDxMQ="
 
 
 def test_content_and_author():
-    result = generate("Hello, world!", "Alice")
+    result = generate_id("Hello, world!", "Alice")
     assert result == "gddVl_z1153y3qEqvF3O6u0fjeo-ghpPD-T0W6RqgZ0="
 
 
 def test_content_and_source():
-    result = generate("Hello, world!", source="Twitter")
+    result = generate_id("Hello, world!", source="Twitter")
     assert result == "XSceRAmkngNM9NVuL9FeDricbCrrPkw8SgvFF9uIVFQ="
 
 
 def test_content_author_and_source():
-    result = generate("Hello, world!", "Alice", "Twitter")
+    result = generate_id("Hello, world!", "Alice", "Twitter")
     assert result == "5tJzOBEpdq0udVD1pAu0V_pn58pvAdaisOlpojBWg2k="
 
 
 def test_cannot_cause_collision_with_author():
-    just_content = generate("Hello there")
-    with_author = generate("Hello", " there")
+    just_content = generate_id("Hello there")
+    with_author = generate_id("Hello", " there")
     assert just_content != with_author
 
 
 def test_cannot_cause_collision_with_source():
-    just_content = generate("Hello there")
-    with_source = generate("Hello", source=" there")
+    just_content = generate_id("Hello there")
+    with_source = generate_id("Hello", source=" there")
     assert just_content != with_source
 
 
 def test_cannot_cause_collision_with_author_and_source():
-    just_content = generate("Hello there")
-    with_author_and_source = generate("Hello", " ", " there")
+    just_content = generate_id("Hello there")
+    with_author_and_source = generate_id("Hello", " ", " there")
     assert just_content != with_author_and_source
 
 
 def test_whitespace_surrounding_content_is_ignored():
-    without_whitespace = generate("Hello, world!")
-    with_whitespace = generate(" \t Hello, world!\r\n ")
+    without_whitespace = generate_id("Hello, world!")
+    with_whitespace = generate_id(" \t Hello, world!\r\n ")
     assert without_whitespace == with_whitespace
 
 
 def test_whitespace_surrounding_author_is_ignored():
-    without_whitespace = generate("Hello, world!", "Alice")
-    with_whitespace = generate("Hello, world!", " \t Alice\r\n ")
+    without_whitespace = generate_id("Hello, world!", "Alice")
+    with_whitespace = generate_id("Hello, world!", " \t Alice\r\n ")
     assert without_whitespace == with_whitespace
 
 
 def test_whitespace_surrounding_source_is_ignored():
-    without_whitespace = generate("Hello, world!", source="Twitter")
-    with_whitespace = generate("Hello, world!", source=" \t Twitter\r\n ")
+    without_whitespace = generate_id("Hello, world!", source="Twitter")
+    with_whitespace = generate_id("Hello, world!", source=" \t Twitter\r\n ")
     assert without_whitespace == with_whitespace
 
 
 def test_all_surrounding_whitespace_is_ignored():
-    without_whitespace = generate("Hello, world!", "Alice", "Twitter")
-    with_whitespace = generate("\t \nHello, world!\r\n", " \t Alice\r\n ", " \t Twitter\r\n ")
+    without_whitespace = generate_id("Hello, world!", "Alice", "Twitter")
+    with_whitespace = generate_id("\t \nHello, world!\r\n", " \t Alice\r\n ", " \t Twitter\r\n ")
     assert without_whitespace == with_whitespace


### PR DESCRIPTION
Despite VSCode recognizing the import `from veritasai import document_id`, an isolated Python interpreter (like those that run Cloud Functions) does not. This is because the root of the `veritasai` namespace is not a package. There does not appear to be a way to make the root namespace a package as it is constructed by the Polylith build hooks.