### PR TITLE
Fix diff check for polylith lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,7 +65,7 @@ jobs:
       - run: |
           pdm run poly sync
 
-          if ! git diff --quiet pyproject.toml; then
+          if ! git diff --quiet HEAD; then
             echo "not all bricks are in sync, please run 'pdm run poly sync' and commit the changes."
             exit 1
           fi

--- a/projects/analysis-manager/pyproject.toml
+++ b/projects/analysis-manager/pyproject.toml
@@ -18,3 +18,4 @@ includes = ["main.py", "requirements.txt"]
 [tool.polylith.bricks]
 "../../bases/veritasai/analysis_manager" = "veritasai/analysis_manager"
 "../../components/veritasai/input_validation" = "veritasai/input_validation"
+"../../components/veritasai/document_id" = "veritasai/document_id"


### PR DESCRIPTION
Fixes the condition for checking if the Polylith components are all in sync. This ensures the projects are correctly linked to their dependencies.

Also, fixes the analysis-manager project to ensure it is linked to the document_id component.