### PR TITLE
Allow ruff to detect line endings, instead of forcing lf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ indent-width = 4
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
-line-ending = "lf"
+line-ending = "auto"
 docstring-code-format = true
 
 [tool.ruff.lint]


### PR DESCRIPTION
Allows `ruff format` to detect line endings per-file. This should work nicely with the `core.autocrlf` git option for Windows users.