### PR TITLE
Define data model for events sent over Cloud Pub/Sub

### DIFF
--- a/components/veritasai/protocol/__init__.py
+++ b/components/veritasai/protocol/__init__.py
@@ -1,0 +1,3 @@
+from .message import Payload
+
+__all__ = ["Payload"]

--- a/components/veritasai/protocol/message.py
+++ b/components/veritasai/protocol/message.py
@@ -1,0 +1,32 @@
+import json
+from base64 import b64decode
+from dataclasses import dataclass
+
+from cloudevents.http import CloudEvent
+
+
+@dataclass(frozen=True)
+class Payload:
+    """
+    The payload sent from the analysis-manager to individual analyzers.
+    """
+
+    id: str
+    author: str | None = None
+    publisher: str | None = None
+    url: str | None = None
+
+    @classmethod
+    def from_cloud_event(cls, event: CloudEvent) -> "Payload":
+        """
+        Extract the payload from a Pub/Sub message.
+
+        :param event: the source event
+        :return: the sent payload
+        """
+        assert event.get("type") == "google.cloud.pubsub.topic.v1.messagePublished"
+
+        raw = b64decode(event.data["message"]["data"])
+        deserialized = json.loads(raw)
+
+        return cls(**deserialized)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,16 @@ analysis-manager.env = { PORT = "8080" }
 "components/veritasai/firebase" = "veritasai/firebase"
 "components/veritasai/cache" = "veritasai/cache"
 "components/veritasai/articles" = "veritasai/articles"
+"components/veritasai/protocol" = "veritasai/protocol"
 
 [tool.pyright]
 extraPaths = ["bases", "components"]
 
 [tool.pytest.ini_options]
-markers = ["function: mark a test as requiring an instance of a handler function"]
+markers = [
+  "function: mark a test as requiring an instance of a handler function",
+  "cloud_event: specify the content of a cloud event",
+]
 
 [tool.ruff]
 line-length = 100

--- a/test/components/veritasai/protocol/test_payload.py
+++ b/test/components/veritasai/protocol/test_payload.py
@@ -1,0 +1,110 @@
+import json
+from base64 import b64encode
+from datetime import datetime
+
+import pytest
+from cloudevents.http import CloudEvent
+from pytest import FixtureRequest
+from veritasai.protocol import Payload
+
+
+@pytest.fixture
+def cloud_event(request: FixtureRequest) -> CloudEvent:
+    """
+    Create a new CloudEvent for testing purposes.
+    """
+    marker = request.node.get_closest_marker("cloud_event")
+    if not marker:
+        raise ValueError("Test must be marked with `@pytest.mark.cloud_event`")
+
+    if not isinstance(marker.args[0], dict):
+        raise ValueError("CloudEvent marker must have a dictionary argument")
+
+    serialized = json.dumps(marker.args[0])
+    encoded = b64encode(serialized.encode()).decode()
+
+    return CloudEvent(
+        attributes={
+            "specversion": "1.0",
+            "type": "google.cloud.pubsub.topic.v1.messagePublished",
+            "source": "//pubsub.googleapis.com/projects/testing/topic/test",
+            "time": datetime.now().isoformat(),
+        },
+        data={"message": {"data": encoded}},
+    )
+
+
+def test_payloads_are_immutable():
+    payload = Payload(id="some-id", author="Alice", publisher="Twitter", url="https://example.com")
+
+    with pytest.raises(AttributeError):
+        payload.id = "some-other-id"
+
+
+@pytest.mark.cloud_event(
+    {
+        "id": "some-id",
+        "author": "Alice",
+        "publisher": "Twitter",
+        "url": "https://example.com",
+    }
+)
+def test_from_cloud_event(cloud_event: CloudEvent):
+    assert Payload.from_cloud_event(cloud_event) == Payload(
+        id="some-id",
+        author="Alice",
+        publisher="Twitter",
+        url="https://example.com",
+    )
+
+
+@pytest.mark.cloud_event(
+    {
+        "id": "some-id",
+        "publisher": "Twitter",
+        "url": "https://example.com",
+    }
+)
+def test_from_cloud_event_missing_author(cloud_event: CloudEvent):
+    assert Payload.from_cloud_event(cloud_event) == Payload(
+        id="some-id",
+        publisher="Twitter",
+        url="https://example.com",
+    )
+
+
+@pytest.mark.cloud_event(
+    {
+        "id": "some-id",
+        "author": "Alice",
+        "url": "https://example.com",
+    }
+)
+def test_from_cloud_event_missing_publisher(cloud_event: CloudEvent):
+    assert Payload.from_cloud_event(cloud_event) == Payload(
+        id="some-id",
+        author="Alice",
+        url="https://example.com",
+    )
+
+
+@pytest.mark.cloud_event(
+    {
+        "id": "some-id",
+        "author": "Alice",
+        "publisher": "Twitter",
+    }
+)
+def test_from_cloud_event_missing_url(cloud_event: CloudEvent):
+    assert Payload.from_cloud_event(cloud_event) == Payload(
+        id="some-id",
+        author="Alice",
+        publisher="Twitter",
+    )
+
+
+@pytest.mark.cloud_event({"id": "some-id"})
+def test_from_cloud_event_minimal(cloud_event: CloudEvent):
+    assert Payload.from_cloud_event(cloud_event) == Payload(
+        id="some-id",
+    )


### PR DESCRIPTION
Creates the data model for messages sent over Pub/Sub to include only the necessary data for processing. At this point, the article content is intentionally left out due to bandwidth constraints.