### PR TITLE
Store article content externally from Pub/Sub messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # The path to the Firebase Admin SDK service account key file
 FIREBASE_SERVICE_ACCOUNT=/path/to/firebase-adminsdk/service-account.json
+
+# The bucket to store article content in
+ARTICLES_BUCKET=some-bucket-name

--- a/components/veritasai/protocol/message.py
+++ b/components/veritasai/protocol/message.py
@@ -1,8 +1,11 @@
 import json
 from base64 import b64decode
 from dataclasses import dataclass
+from functools import cached_property
 
 from cloudevents.http import CloudEvent
+
+from .storage import retrieve_content, save_content
 
 
 @dataclass(frozen=True)
@@ -15,6 +18,31 @@ class Payload:
     author: str | None = None
     publisher: str | None = None
     url: str | None = None
+
+    @classmethod
+    def create(
+        cls,
+        article_id: str,
+        content: str,
+        author: str | None = None,
+        publisher: str | None = None,
+        url: str | None = None,
+    ) -> "Payload":
+        """
+        Create a new Pub/Sub message payload.
+
+        Article content is stored externally in a storage bucket to reduce the size of the message.
+
+        :param article_id: the unique ID of the article
+        :param content: the article's content
+        :param author: the article's author, if any
+        :param publisher: the article's publisher, if any
+        :param url: the article's URL, if any
+        :return: the created payload
+        """
+        save_content(article_id, content)
+
+        return cls(id=article_id, author=author, publisher=publisher, url=url)
 
     @classmethod
     def from_cloud_event(cls, event: CloudEvent) -> "Payload":
@@ -30,3 +58,14 @@ class Payload:
         deserialized = json.loads(raw)
 
         return cls(**deserialized)
+
+    @cached_property
+    def content(self) -> str:
+        """
+        Retrieve the externally stored article content from the storage bucket.
+        """
+        content = retrieve_content(self.id)
+        if content is None:
+            raise ValueError(f"article {self.id!r} not found")
+
+        return content

--- a/components/veritasai/protocol/storage.py
+++ b/components/veritasai/protocol/storage.py
@@ -1,0 +1,72 @@
+from os import environ
+
+from google.cloud import storage
+from google.cloud.exceptions import NotFound, PreconditionFailed
+
+_client = None
+
+
+def _get_client() -> storage.Client:
+    """
+    Get the storage client.
+
+    Automatically creates a new client if one does not already exist.
+
+    :return: the storage client
+    """
+    global _client
+
+    if _client is None:
+        _client = storage.Client()
+
+    return _client
+
+
+def _get_bucket() -> storage.Bucket:
+    """
+    Get the storage bucket.
+
+    Retrieves the bucket as configured by the ARTICLES_BUCKET environment variable.
+
+    :return: the storage bucket
+    """
+    client = _get_client()
+
+    bucket_name = environ.get("ARTICLES_BUCKET")
+    if bucket_name is None:
+        raise ValueError("environment variable ARTICLES_BUCKET is not set")
+
+    return client.bucket(bucket_name)
+
+
+def save_content(article_id: str, content: str):
+    """
+    Save the content of an article to a storage bucket.
+
+    :param article_id: the article's unique ID
+    :param content: the article's content
+    """
+    bucket = _get_bucket()
+    blob = bucket.blob(article_id)
+
+    try:
+        blob.upload_from_string(content, content_type="text/plain", if_generation_match=0)
+    except PreconditionFailed:
+        # Already uploaded, nothing to do
+        pass
+
+
+def retrieve_content(article_id: str) -> str | None:
+    """
+    Retrieve the content of an article from a storage bucket.
+
+    :param article_id: the article's unique ID
+    :return: the article's content, or None if the article does not exist
+    """
+    bucket = _get_bucket()
+    blob = bucket.blob(article_id)
+
+    try:
+        return blob.download_as_string().decode("utf-8")
+    except NotFound:
+        return None

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:2a46fd303f7c5be923d0cd0dd4912bd99c6b9e062ab355ac3e1a5def9556b0a6"
+content_hash = "sha256:7d835927350593de1cc17d951095fbd1181b5c7dc33b3d988324fd8f45b9f751"
 
 [[package]]
 name = "annotated-types"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "google-cloud-language>=2.13.3",
   "python-dotenv>=1.0.1",
   "firebase-admin>=6.5.0",
+  "google-cloud-storage>=2.16.0",
 ]
 
 [build-system]

--- a/test/components/veritasai/protocol/test_storage.py
+++ b/test/components/veritasai/protocol/test_storage.py
@@ -1,0 +1,74 @@
+import pytest
+from google.cloud.exceptions import NotFound, PreconditionFailed
+from pytest import MonkeyPatch
+from pytest_mock import MockerFixture
+from veritasai.protocol.storage import retrieve_content, save_content
+
+
+@pytest.fixture(autouse=True)
+def set_articles_bucket(monkeypatch: MonkeyPatch):
+    """
+    Set the ARTICLES_BUCKET environment variable to "test-bucket".
+    """
+    with monkeypatch.context() as m:
+        m.setenv("ARTICLES_BUCKET", "test-bucket")
+
+        yield
+
+
+def test_save_content(mocker: MockerFixture):
+    client = mocker.MagicMock()
+    mocker.patch("veritasai.protocol.storage._get_client", return_value=client)
+
+    save_content("test-article-id", "Hello, world!")
+
+    client.bucket.assert_called_once_with("test-bucket")
+    client.bucket.return_value.blob.assert_called_once_with("test-article-id")
+    client.bucket.return_value.blob.return_value.upload_from_string.assert_called_once_with(
+        "Hello, world!",
+        content_type="text/plain",
+        if_generation_match=0,
+    )
+
+
+def test_save_content_when_already_exists(mocker: MockerFixture):
+    client = mocker.MagicMock()
+    client.bucket.return_value.blob.return_value.upload_from_string.side_effect = (
+        PreconditionFailed("id")
+    )
+    mocker.patch("veritasai.protocol.storage._get_client", return_value=client)
+
+    save_content("test-article-id", "Hello, world!")
+
+    client.bucket.assert_called_once_with("test-bucket")
+    client.bucket.return_value.blob.assert_called_once_with("test-article-id")
+    client.bucket.return_value.blob.return_value.upload_from_string.assert_called_once_with(
+        "Hello, world!",
+        content_type="text/plain",
+        if_generation_match=0,
+    )
+
+
+def test_retrieve_content_when_exists(mocker: MockerFixture):
+    client = mocker.MagicMock()
+    client.bucket.return_value.blob.return_value.exists.return_value = True
+    client.bucket.return_value.blob.return_value.download_as_string.return_value = b"Hello, world!"
+    mocker.patch("veritasai.protocol.storage._get_client", return_value=client)
+
+    assert retrieve_content("test-article-id") == "Hello, world!"
+
+    client.bucket.assert_called_once_with("test-bucket")
+    client.bucket.return_value.blob.assert_called_once_with("test-article-id")
+    client.bucket.return_value.blob.return_value.download_as_string.assert_called_once()
+
+
+def test_retrieve_content_when_does_not_exist(mocker: MockerFixture):
+    client = mocker.MagicMock()
+    client.bucket.return_value.blob.return_value.download_as_string.side_effect = NotFound("id")
+    mocker.patch("veritasai.protocol.storage._get_client", return_value=client)
+
+    assert retrieve_content("test-article-id") is None
+
+    client.bucket.assert_called_once_with("test-bucket")
+    client.bucket.return_value.blob.assert_called_once_with("test-article-id")
+    client.bucket.return_value.blob.return_value.download_as_string.assert_called_once()

--- a/test/components/veritasai/protocol/test_storage.py
+++ b/test/components/veritasai/protocol/test_storage.py
@@ -1,19 +1,6 @@
-import pytest
 from google.cloud.exceptions import NotFound, PreconditionFailed
-from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
 from veritasai.protocol.storage import retrieve_content, save_content
-
-
-@pytest.fixture(autouse=True)
-def set_articles_bucket(monkeypatch: MonkeyPatch):
-    """
-    Set the ARTICLES_BUCKET environment variable to "test-bucket".
-    """
-    with monkeypatch.context() as m:
-        m.setenv("ARTICLES_BUCKET", "test-bucket")
-
-        yield
 
 
 def test_save_content(mocker: MockerFixture):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -93,3 +93,14 @@ def disable_firebase_admin_sdk_initialization(monkeypatch: MonkeyPatch):
         m.setattr("firebase_admin.initialize_app", lambda *args, **kwargs: None)
 
         yield
+
+
+@pytest.fixture(autouse=True)
+def set_articles_bucket(monkeypatch: MonkeyPatch):
+    """
+    Set the ARTICLES_BUCKET environment variable to "test-bucket".
+    """
+    with monkeypatch.context() as m:
+        m.setenv("ARTICLES_BUCKET", "test-bucket")
+
+        yield


### PR DESCRIPTION
Adds the article content to the Pub/Sub message by storing it externally to reduce bandwidth requirements. The content can be accessed using the `Article.content` property.