### PR TITLE
Publish article analysis requests to Cloud Pub/Sub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
 # The path to the Firebase Admin SDK service account key file
 FIREBASE_SERVICE_ACCOUNT=/path/to/firebase-adminsdk/service-account.json
 
+# The project ID of the Google Cloud project
+GOOGLE_CLOUD_PROJECT=your-project-id
+
 # The bucket to store article content in
 ARTICLES_BUCKET=some-bucket-name
+
+# The topic to publish article analysis requests to
+ANALYSIS_REQUESTS_TOPIC=analysis-requests

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+# The project ID of the Google Cloud project
+GOOGLE_CLOUD_PROJECT=test-project
+
+# The bucket to store article content in
+ARTICLES_BUCKET=test-bucket

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,6 @@
   "python.analysis.extraPaths": ["bases", "components"],
   "python.testing.pytestArgs": ["test"],
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true
+  "python.testing.pytestEnabled": true,
+  "python.envFile": ""
 }

--- a/bases/veritasai/analysis_manager/handler.py
+++ b/bases/veritasai/analysis_manager/handler.py
@@ -3,6 +3,7 @@ from flask import Request, typing
 from veritasai.articles import Article
 from veritasai.cache import has_article
 from veritasai.input_validation import AnalyzeText, ValidationError, response_from_validation_error
+from veritasai.pubsub import analysis_requests
 
 
 @functions_framework.http
@@ -24,6 +25,6 @@ def handler(request: Request) -> typing.ResponseReturnValue:
         # TODO: return a response indicating that the document has already been processed
         return "", 204
 
-    # TODO: send pubsub message to analysis worker(s)
+    analysis_requests.publish(article)
 
     return "", 204

--- a/components/veritasai/articles/article.py
+++ b/components/veritasai/articles/article.py
@@ -115,6 +115,18 @@ class Article:
 
         return content
 
+    def to_dict(self) -> dict[str, str]:
+        serialized = {"id": self.id}
+
+        if self.author:
+            serialized["author"] = self.author
+        if self.publisher:
+            serialized["publisher"] = self.publisher
+        if self.url:
+            serialized["url"] = self.url
+
+        return serialized
+
     def __repr__(self) -> str:
         return (
             "Article("

--- a/components/veritasai/articles/storage.py
+++ b/components/veritasai/articles/storage.py
@@ -1,7 +1,6 @@
-from os import environ
-
 from google.cloud import storage
 from google.cloud.exceptions import NotFound, PreconditionFailed
+from veritasai.config import env
 
 _client = None
 
@@ -32,7 +31,7 @@ def _get_bucket() -> storage.Bucket:
     """
     client = _get_client()
 
-    bucket_name = environ.get("ARTICLES_BUCKET")
+    bucket_name = env.get("ARTICLES_BUCKET")
     if bucket_name is None:
         raise ValueError("environment variable ARTICLES_BUCKET is not set")
 

--- a/components/veritasai/config/__init__.py
+++ b/components/veritasai/config/__init__.py
@@ -1,0 +1,14 @@
+import os
+
+from dotenv import dotenv_values
+
+from . import location
+
+env = dotenv_values(f".env.{location.name}")
+
+if location.is_development:
+    env.update(dotenv_values(".env"))
+
+env.update(os.environ)
+
+__all__ = ["env", "location"]

--- a/components/veritasai/config/location.py
+++ b/components/veritasai/config/location.py
@@ -1,0 +1,27 @@
+"""
+Metadata about where the application is running.
+"""
+
+from os import environ
+from sys import modules
+
+VALID_ENVIRONMENTS = {"development", "production", "test"}
+
+if (app_env := environ.get("APP_ENV")) is not None:
+    name = app_env.lower().strip()
+
+    if name not in VALID_ENVIRONMENTS:
+        raise ValueError(f"Invalid APP_ENV: {app_env}")
+
+elif "pytest" in modules:
+    name = "test"
+
+elif "K_SERVICE" in environ and "K_REVISION" in environ:
+    name = "production"
+
+else:
+    name = "development"
+
+
+is_development = name == "development"
+is_production = name == "production"

--- a/components/veritasai/firebase/__init__.py
+++ b/components/veritasai/firebase/__init__.py
@@ -1,10 +1,9 @@
-from os import environ
-
 import firebase_admin
 from dotenv import load_dotenv
 from firebase_admin import firestore
 from firebase_admin.credentials import ApplicationDefault, Base, Certificate
 from google.cloud.firestore import Client
+from veritasai.config import env
 
 load_dotenv()
 
@@ -15,7 +14,7 @@ def _get_credentials() -> Base:
     """
     credentials = ApplicationDefault()
 
-    if (service_account := environ.get("FIREBASE_SERVICE_ACCOUNT")) is not None:
+    if (service_account := env.get("FIREBASE_SERVICE_ACCOUNT")) is not None:
         credentials = Certificate(service_account)
 
     return credentials

--- a/components/veritasai/pubsub/__init__.py
+++ b/components/veritasai/pubsub/__init__.py
@@ -1,0 +1,6 @@
+from . import topics
+from .publisher import Publisher, Serializable
+
+analysis_requests = Publisher(topics.analysis_requests)
+
+__all__ = ["analysis_requests", "Publisher", "Serializable"]

--- a/components/veritasai/pubsub/publisher.py
+++ b/components/veritasai/pubsub/publisher.py
@@ -1,0 +1,53 @@
+import json
+from os import environ
+from typing import Protocol
+
+from google.cloud.pubsub import PublisherClient
+
+
+class Serializable(Protocol):
+    """
+    Protocol for objects that can be serialized to a dictionary.
+    """
+
+    def to_dict(self) -> dict:
+        """
+        Serialize the object to a dictionary.
+        """
+        ...
+
+
+class Publisher:
+    """
+    Publishes messages to a topic.
+    """
+
+    def __init__(self, topic: str, project: str | None = None):
+        """
+        Initialize a publisher.
+
+        The project ID is automatically determined from the environment when available. If it is not
+        available, it must be provided.using the GOOGLE_CLOUD_PROJECT environment variable.
+
+        :param topic: The name of the topic to publish to.
+        :param project: The name of the project that owns the topic.
+        """
+
+        if project is None:
+            project = environ.get("GOOGLE_CLOUD_PROJECT")
+        if project is None:
+            raise ValueError("unknown project ID")
+
+        self.__topic = f"projects/{project}/topics/{topic}"
+        self.__client = PublisherClient()
+
+    def publish(self, message: Serializable):
+        """
+        Publish the message to the appropriate topic.
+
+        :param message: The message to publish.
+        """
+        data = json.dumps(message.to_dict()).encode("utf-8")
+        result = self.__client.publish(topic=self.__topic, data=data)
+
+        result.result()

--- a/components/veritasai/pubsub/publisher.py
+++ b/components/veritasai/pubsub/publisher.py
@@ -41,6 +41,13 @@ class Publisher:
         self.__topic = f"projects/{project}/topics/{topic}"
         self.__client = PublisherClient()
 
+    @property
+    def topic(self) -> str:
+        """
+        The fully qualified name of the topic.
+        """
+        return self.__topic
+
     def publish(self, message: Serializable):
         """
         Publish the message to the appropriate topic.

--- a/components/veritasai/pubsub/publisher.py
+++ b/components/veritasai/pubsub/publisher.py
@@ -39,7 +39,7 @@ class Publisher:
             raise ValueError("unknown project ID")
 
         self.__topic = f"projects/{project}/topics/{topic}"
-        self.__client = PublisherClient()
+        self.__client = None
 
     @property
     def topic(self) -> str:
@@ -54,6 +54,9 @@ class Publisher:
 
         :param message: The message to publish.
         """
+        if self.__client is None:
+            self.__client = PublisherClient()
+
         data = json.dumps(message.to_dict()).encode("utf-8")
         result = self.__client.publish(topic=self.__topic, data=data)
 

--- a/components/veritasai/pubsub/publisher.py
+++ b/components/veritasai/pubsub/publisher.py
@@ -1,8 +1,8 @@
 import json
-from os import environ
 from typing import Protocol
 
 from google.cloud.pubsub import PublisherClient
+from veritasai.config import env
 
 
 class Serializable(Protocol):
@@ -34,7 +34,7 @@ class Publisher:
         """
 
         if project is None:
-            project = environ.get("GOOGLE_CLOUD_PROJECT")
+            project = env.get("GOOGLE_CLOUD_PROJECT")
         if project is None:
             raise ValueError("unknown project ID")
 

--- a/components/veritasai/pubsub/topics.py
+++ b/components/veritasai/pubsub/topics.py
@@ -1,4 +1,4 @@
-from os import environ
+from veritasai.config import env
 
 
 def topic_name_from_environment(name: str, default: str | None = None) -> str:
@@ -7,7 +7,7 @@ def topic_name_from_environment(name: str, default: str | None = None) -> str:
 
     :param name: The name of the environment variable.
     """
-    topic = environ.get(name, default)
+    topic = env.get(name, default)
     if topic is None or len(topic.strip()) == 0:
         raise ValueError(f"missing topic name for {name}")
 

--- a/components/veritasai/pubsub/topics.py
+++ b/components/veritasai/pubsub/topics.py
@@ -1,0 +1,17 @@
+from os import environ
+
+
+def topic_name_from_environment(name: str, default: str | None = None) -> str:
+    """
+    Get the topic name from the environment.
+
+    :param name: The name of the environment variable.
+    """
+    topic = environ.get(name, default)
+    if topic is None or len(topic.strip()) == 0:
+        raise ValueError(f"missing topic name for {name}")
+
+    return topic.strip()
+
+
+analysis_requests = topic_name_from_environment("ANALYSIS_REQUESTS_TOPIC", "analysis-requests")

--- a/development/function.py
+++ b/development/function.py
@@ -1,7 +1,7 @@
-from os import environ
 from pathlib import Path
 
 from functions_framework import create_app
+from veritasai.config import env
 
 
 def find_project_root_directory() -> Path:
@@ -18,7 +18,7 @@ def find_project_root_directory() -> Path:
     raise FileNotFoundError("Could not find the project root directory")
 
 
-FUNCTION = environ.get("FUNCTION")
+FUNCTION = env.get("FUNCTION")
 if FUNCTION is None or len(FUNCTION) == 0:
     raise ValueError("The FUNCTION environment variable must be set")
 

--- a/development/testsupport/__init__.py
+++ b/development/testsupport/__init__.py
@@ -1,0 +1,17 @@
+from typing import Generator
+
+import pytest
+
+from .config import ConfigPatch
+
+__all__ = ["ConfigPatch"]
+
+
+@pytest.fixture
+def env_var() -> Generator[ConfigPatch, None, None]:
+    """
+    Patch environment variables for the duration of the test.
+    """
+    patcher = ConfigPatch()
+    yield patcher
+    patcher.undo()

--- a/development/testsupport/config.py
+++ b/development/testsupport/config.py
@@ -1,0 +1,41 @@
+from veritasai.config import env
+
+
+class ConfigPatch:
+    """
+    A utility for temporarily overriding environment variables.
+    """
+
+    def __init__(self, source: dict[str, str] | None = None):
+        self._env = source or env
+        self._original = {}
+
+    def set(self, key: str, value: str | None):
+        """
+        Override an environment variable.
+        """
+        self._original[key] = env.get(key)
+        env[key] = value
+
+    def remove(self, key: str):
+        """
+        Remove an environment variable.
+        """
+        self._original[key] = env.pop(key, None)
+
+    @property
+    def values(self) -> dict[str, str]:
+        """
+        Retrieve the current environment variables.
+        """
+        return self._env
+
+    def undo(self):
+        """
+        Undo all changes.
+        """
+        for key, value in self._original.items():
+            if value is None:
+                env.pop(key, None)
+            else:
+                env[key] = value

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:7d835927350593de1cc17d951095fbd1181b5c7dc33b3d988324fd8f45b9f751"
+content_hash = "sha256:f5cc7b5fd7fbeb722be6d45a03677def9ef9285b3de58abf36bfc81883acc5b1"
 
 [[package]]
 name = "annotated-types"
@@ -469,6 +469,27 @@ files = [
 ]
 
 [[package]]
+name = "google-cloud-pubsub"
+version = "2.21.1"
+requires_python = ">=3.7"
+summary = "Google Cloud Pub/Sub API client library"
+groups = ["default"]
+dependencies = [
+    "google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.0",
+    "google-auth<3.0.0dev,>=2.14.1",
+    "grpc-google-iam-v1<1.0.0dev,>=0.12.4",
+    "grpcio-status>=1.33.2",
+    "grpcio<2.0dev,>=1.51.3",
+    "proto-plus<2.0.0dev,>=1.22.0",
+    "proto-plus<2.0.0dev,>=1.22.2; python_version >= \"3.11\"",
+    "protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5",
+]
+files = [
+    {file = "google-cloud-pubsub-2.21.1.tar.gz", hash = "sha256:31fcf07444b7f813a616c4b650e1fbf1dc998a088fe0059a76164855ac17f05c"},
+    {file = "google_cloud_pubsub-2.21.1-py2.py3-none-any.whl", hash = "sha256:55a3602ec45bc09626604d712032288a8ee3566145cb83523cff908938f69a4b"},
+]
+
+[[package]]
 name = "google-cloud-storage"
 version = "2.16.0"
 requires_python = ">=3.7"
@@ -558,6 +579,38 @@ dependencies = [
 files = [
     {file = "googleapis-common-protos-1.63.0.tar.gz", hash = "sha256:17ad01b11d5f1d0171c06d3ba5c04c54474e883b66b949722b4938ee2694ef4e"},
     {file = "googleapis_common_protos-1.63.0-py2.py3-none-any.whl", hash = "sha256:ae45f75702f7c08b541f750854a678bd8f534a1a6bace6afe975f1d0a82d6632"},
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.63.0"
+extras = ["grpc"]
+requires_python = ">=3.7"
+summary = "Common protobufs used in Google APIs"
+groups = ["default"]
+dependencies = [
+    "googleapis-common-protos==1.63.0",
+    "grpcio<2.0.0.dev0,>=1.44.0",
+]
+files = [
+    {file = "googleapis-common-protos-1.63.0.tar.gz", hash = "sha256:17ad01b11d5f1d0171c06d3ba5c04c54474e883b66b949722b4938ee2694ef4e"},
+    {file = "googleapis_common_protos-1.63.0-py2.py3-none-any.whl", hash = "sha256:ae45f75702f7c08b541f750854a678bd8f534a1a6bace6afe975f1d0a82d6632"},
+]
+
+[[package]]
+name = "grpc-google-iam-v1"
+version = "0.13.0"
+requires_python = ">=3.7"
+summary = "IAM API client library"
+groups = ["default"]
+dependencies = [
+    "googleapis-common-protos[grpc]<2.0.0dev,>=1.56.0",
+    "grpcio<2.0.0dev,>=1.44.0",
+    "protobuf!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5",
+]
+files = [
+    {file = "grpc-google-iam-v1-0.13.0.tar.gz", hash = "sha256:fad318608b9e093258fbf12529180f400d1c44453698a33509cc6ecf005b294e"},
+    {file = "grpc_google_iam_v1-0.13.0-py2.py3-none-any.whl", hash = "sha256:53902e2af7de8df8c1bd91373d9be55b0743ec267a7428ea638db3775becae89"},
 ]
 
 [[package]]

--- a/projects/analysis-manager/pyproject.toml
+++ b/projects/analysis-manager/pyproject.toml
@@ -24,7 +24,9 @@ includes = ["main.py", "requirements.txt"]
 
 [tool.polylith.bricks]
 "../../bases/veritasai/analysis_manager" = "veritasai/analysis_manager"
-"../../components/veritasai/input_validation" = "veritasai/input_validation"
-"../../components/veritasai/cache" = "veritasai/cache"
-"../../components/veritasai/firebase" = "veritasai/firebase"
 "../../components/veritasai/articles" = "veritasai/articles"
+"../../components/veritasai/cache" = "veritasai/cache"
+"../../components/veritasai/config" = "veritasai/config"
+"../../components/veritasai/firebase" = "veritasai/firebase"
+"../../components/veritasai/input_validation" = "veritasai/input_validation"
+"../../components/veritasai/pubsub" = "veritasai/pubsub"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,12 @@ analysis-manager.cmd = "functions-framework --target=handler --source projects/a
 analysis-manager.env = { PORT = "8080" }
 
 [tool.polylith.bricks]
-"components/veritasai/input_validation" = "veritasai/input_validation"
 "bases/veritasai/analysis_manager" = "veritasai/analysis_manager"
-"components/veritasai/firebase" = "veritasai/firebase"
-"components/veritasai/cache" = "veritasai/cache"
 "components/veritasai/articles" = "veritasai/articles"
+"components/veritasai/cache" = "veritasai/cache"
+"components/veritasai/config" = "veritasai/config"
+"components/veritasai/firebase" = "veritasai/firebase"
+"components/veritasai/input_validation" = "veritasai/input_validation"
 "components/veritasai/protocol" = "veritasai/protocol"
 "components/veritasai/pubsub" = "veritasai/pubsub"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "python-dotenv>=1.0.1",
   "firebase-admin>=6.5.0",
   "google-cloud-storage>=2.16.0",
+  "google-cloud-pubsub>=2.21.1",
 ]
 
 [build-system]
@@ -42,6 +43,8 @@ analysis-manager.env = { PORT = "8080" }
 "components/veritasai/firebase" = "veritasai/firebase"
 "components/veritasai/cache" = "veritasai/cache"
 "components/veritasai/articles" = "veritasai/articles"
+"components/veritasai/protocol" = "veritasai/protocol"
+"components/veritasai/pubsub" = "veritasai/pubsub"
 
 [tool.pyright]
 extraPaths = ["bases", "components"]

--- a/test/components/veritasai/articles/test_article_to_dict.py
+++ b/test/components/veritasai/articles/test_article_to_dict.py
@@ -1,0 +1,34 @@
+import pytest
+from veritasai.articles import Article
+
+
+def test_all_fields_serialized_if_exists():
+    article = Article(
+        id="123",
+        author="John Doe",
+        publisher="The New York Times",
+        url="https://nytimes.com",
+    )
+    assert article.to_dict() == {
+        "id": "123",
+        "author": "John Doe",
+        "publisher": "The New York Times",
+        "url": "https://nytimes.com",
+    }
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["author", "publisher", "url"],
+)
+def test_fields_not_serialized_when_missing(field):
+    fields = {
+        "id": "123",
+        "author": "John Doe",
+        "publisher": "The New York Times",
+        "url": "https://nytimes.com",
+    }
+    del fields[field]
+    article = Article(**fields)
+
+    assert article.to_dict() == fields

--- a/test/components/veritasai/config/location.py
+++ b/test/components/veritasai/config/location.py
@@ -1,0 +1,7 @@
+from veritasai.config import location
+
+
+def test_pytest_is_always_test_environment():
+    assert location.name == "test"
+    assert not location.is_development
+    assert not location.is_production

--- a/test/components/veritasai/firebase/test_credentials.py
+++ b/test/components/veritasai/firebase/test_credentials.py
@@ -1,23 +1,19 @@
 from pathlib import Path
 
 from firebase_admin.credentials import ApplicationDefault, Certificate
-from pytest import MonkeyPatch
 from veritasai.firebase import _get_credentials
 
-
-def test_loads_from_application_default_credentials(monkeypatch: MonkeyPatch):
-    with monkeypatch.context() as m:
-        m.delenv("FIREBASE_SERVICE_ACCOUNT", raising=False)
-
-        credential = _get_credentials()
-        assert isinstance(credential, ApplicationDefault)
+from development.testsupport import ConfigPatch
 
 
-def test_loads_from_certificate_when_environment_variable_set(monkeypatch: MonkeyPatch):
+def test_loads_from_application_default_credentials():
+    credential = _get_credentials()
+    assert isinstance(credential, ApplicationDefault)
+
+
+def test_loads_from_certificate_when_environment_variable_set(env_var: ConfigPatch):
     service_account = Path(__file__).parent / "testdata" / "service_account.json"
+    env_var.set("FIREBASE_SERVICE_ACCOUNT", str(service_account))
 
-    with monkeypatch.context() as m:
-        m.setenv("FIREBASE_SERVICE_ACCOUNT", str(service_account))
-
-        credential = _get_credentials()
-        assert isinstance(credential, Certificate)
+    credential = _get_credentials()
+    assert isinstance(credential, Certificate)

--- a/test/components/veritasai/pubsub/test_publisher.py
+++ b/test/components/veritasai/pubsub/test_publisher.py
@@ -1,0 +1,62 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from veritasai.pubsub.publisher import Publisher
+
+from development.testsupport import ConfigPatch
+
+
+def test_raises_error_when_project_id_is_undefined(env_var: ConfigPatch):
+    env_var.remove("GOOGLE_CLOUD_PROJECT")
+
+    with pytest.raises(ValueError):
+        Publisher("topic")
+
+
+def test_pulls_project_id_from_environment_when_available():
+    publisher = Publisher("topic")
+    assert publisher.topic == "projects/test-project/topics/topic"
+
+
+def test_uses_explicit_project_id_when_provided():
+    publisher = Publisher("topic", "some-project")
+    assert publisher.topic == "projects/some-project/topics/topic"
+
+
+def test_formats_topic_name_correctly():
+    publisher = Publisher("some-topic", "some-project")
+    assert publisher.topic == "projects/some-project/topics/some-topic"
+
+
+@pytest.fixture
+def publisher():
+    """
+    Create a publisher for testing.
+    """
+    return Publisher("topic")
+
+
+def test_publish_publishes_message_to_topic(publisher: Publisher, mock_pubsub: MagicMock):
+    message = MagicMock(**{"to_dict.return_value": {"key": "value"}})
+    publisher.publish(message)
+
+    mock_pubsub.return_value.publish.assert_called_once_with(
+        topic="projects/test-project/topics/topic", data=b'{"key": "value"}'
+    )
+
+
+def test_publish_sends_valid_json(publisher: Publisher, mock_pubsub: MagicMock):
+    data = {"key": "value"}
+    message = MagicMock(**{"to_dict.return_value": data})
+
+    publisher.publish(message)
+
+    encoded = mock_pubsub.return_value.publish.call_args[1]["data"].decode("utf-8")
+    assert json.loads(encoded) == data
+
+
+def test_publish_waits_for_publish_to_complete(publisher: Publisher, mock_pubsub: MagicMock):
+    publisher.publish(MagicMock(**{"to_dict.return_value": {}}))
+
+    mock_pubsub.return_value.publish.return_value.result.assert_called_once()

--- a/test/components/veritasai/pubsub/test_topics.py
+++ b/test/components/veritasai/pubsub/test_topics.py
@@ -1,6 +1,7 @@
 import pytest
-from pytest import MonkeyPatch
 from veritasai.pubsub.topics import topic_name_from_environment
+
+from development.testsupport import ConfigPatch
 
 
 def test_missing_environment_variable_without_default_raises_error():
@@ -12,28 +13,28 @@ def test_missing_environment_variable_with_default_returns_default():
     assert topic_name_from_environment("TEST_TOPIC", "default") == "default"
 
 
-def test_set_but_empty_environment_variable_raises_error(monkeypatch: MonkeyPatch):
-    monkeypatch.setenv("TEST_TOPIC", "")
+def test_set_but_empty_environment_variable_raises_error(env_var: ConfigPatch):
+    env_var.set("TEST_TOPIC", "")
 
     with pytest.raises(ValueError):
         topic_name_from_environment("TEST_TOPIC")
 
 
-def test_set_and_non_empty_environment_variable_returns_value(monkeypatch: MonkeyPatch):
-    monkeypatch.setenv("TEST_TOPIC", "test-topic")
+def test_set_and_non_empty_environment_variable_returns_value(env_var: ConfigPatch):
+    env_var.set("TEST_TOPIC", "test-topic")
 
     assert topic_name_from_environment("TEST_TOPIC") == "test-topic"
 
 
 def test_set_and_non_empty_environment_variable_with_default_returns_value(
-    monkeypatch: MonkeyPatch,
+    env_var: ConfigPatch,
 ):
-    monkeypatch.setenv("TEST_TOPIC", "test-topic")
+    env_var.set("TEST_TOPIC", "test-topic")
 
     assert topic_name_from_environment("TEST_TOPIC", "default") == "test-topic"
 
 
-def test_set_and_non_empty_environment_variable_has_whitespace_removed(monkeypatch: MonkeyPatch):
-    monkeypatch.setenv("TEST_TOPIC", " test-topic ")
+def test_set_and_non_empty_environment_variable_has_whitespace_removed(env_var: ConfigPatch):
+    env_var.set("TEST_TOPIC", " test-topic ")
 
     assert topic_name_from_environment("TEST_TOPIC") == "test-topic"

--- a/test/components/veritasai/pubsub/test_topics.py
+++ b/test/components/veritasai/pubsub/test_topics.py
@@ -1,0 +1,39 @@
+import pytest
+from pytest import MonkeyPatch
+from veritasai.pubsub.topics import topic_name_from_environment
+
+
+def test_missing_environment_variable_without_default_raises_error():
+    with pytest.raises(ValueError):
+        topic_name_from_environment("TEST_TOPIC")
+
+
+def test_missing_environment_variable_with_default_returns_default():
+    assert topic_name_from_environment("TEST_TOPIC", "default") == "default"
+
+
+def test_set_but_empty_environment_variable_raises_error(monkeypatch: MonkeyPatch):
+    monkeypatch.setenv("TEST_TOPIC", "")
+
+    with pytest.raises(ValueError):
+        topic_name_from_environment("TEST_TOPIC")
+
+
+def test_set_and_non_empty_environment_variable_returns_value(monkeypatch: MonkeyPatch):
+    monkeypatch.setenv("TEST_TOPIC", "test-topic")
+
+    assert topic_name_from_environment("TEST_TOPIC") == "test-topic"
+
+
+def test_set_and_non_empty_environment_variable_with_default_returns_value(
+    monkeypatch: MonkeyPatch,
+):
+    monkeypatch.setenv("TEST_TOPIC", "test-topic")
+
+    assert topic_name_from_environment("TEST_TOPIC", "default") == "test-topic"
+
+
+def test_set_and_non_empty_environment_variable_has_whitespace_removed(monkeypatch: MonkeyPatch):
+    monkeypatch.setenv("TEST_TOPIC", " test-topic ")
+
+    assert topic_name_from_environment("TEST_TOPIC") == "test-topic"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,6 +6,8 @@ from flask.testing import FlaskClient
 from functions_framework import create_app
 from pytest import FixtureRequest, MonkeyPatch
 
+pytest_plugins = "development.testsupport"
+
 
 @pytest.fixture(scope="session")
 def project_root() -> Path:
@@ -72,17 +74,6 @@ def client(app: Flask) -> FlaskClient:
 
 
 @pytest.fixture(autouse=True)
-def disable_dotenv(monkeypatch: MonkeyPatch):
-    """
-    Disable the loading of the .env file for all tests.
-    """
-    with monkeypatch.context() as m:
-        m.setattr("dotenv.load_dotenv", lambda: None)
-
-        yield
-
-
-@pytest.fixture(autouse=True)
 def disable_firebase_admin_sdk_initialization(monkeypatch: MonkeyPatch):
     """
     Disables the initialization process for the Firebase Admin SDK.
@@ -91,27 +82,5 @@ def disable_firebase_admin_sdk_initialization(monkeypatch: MonkeyPatch):
     """
     with monkeypatch.context() as m:
         m.setattr("firebase_admin.initialize_app", lambda *args, **kwargs: None)
-
-        yield
-
-
-@pytest.fixture(autouse=True)
-def set_articles_bucket(monkeypatch: MonkeyPatch):
-    """
-    Set the ARTICLES_BUCKET environment variable to "test-bucket".
-    """
-    with monkeypatch.context() as m:
-        m.setenv("ARTICLES_BUCKET", "test-bucket")
-
-        yield
-
-
-@pytest.fixture(autouse=True)
-def set_project_id(monkeypatch: MonkeyPatch):
-    """
-    Set the GOOGLE_CLOUD_PROJECT environment variable to "test-project".
-    """
-    with monkeypatch.context() as m:
-        m.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
 
         yield

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,7 @@ from flask import Flask
 from flask.testing import FlaskClient
 from functions_framework import create_app
 from pytest import FixtureRequest, MonkeyPatch
+from pytest_mock import MockerFixture
 
 pytest_plugins = "development.testsupport"
 
@@ -84,3 +85,11 @@ def disable_firebase_admin_sdk_initialization(monkeypatch: MonkeyPatch):
         m.setattr("firebase_admin.initialize_app", lambda *args, **kwargs: None)
 
         yield
+
+
+@pytest.fixture(autouse=True)
+def mock_pubsub(mocker: MockerFixture):
+    """
+    Mock the `PublisherClient` class from the `google.cloud.pubsub` module.
+    """
+    return mocker.patch("veritasai.pubsub.publisher.PublisherClient")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -104,3 +104,14 @@ def set_articles_bucket(monkeypatch: MonkeyPatch):
         m.setenv("ARTICLES_BUCKET", "test-bucket")
 
         yield
+
+
+@pytest.fixture(autouse=True)
+def set_project_id(monkeypatch: MonkeyPatch):
+    """
+    Set the GOOGLE_CLOUD_PROJECT environment variable to "test-project".
+    """
+    with monkeypatch.context() as m:
+        m.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
+
+        yield


### PR DESCRIPTION
Adds a new `pubsub` component to handle publishing messages to Cloud Pub/Sub. Additionally, a `config` component was added to allow for hierarchical configuration loading of .env files.

Depending on the environment, different environment files are loaded. The files loaded in each environment are loaded as followed:
- `development`: .env, .env.development
- `production`: .env.production
- `test`: .env.test