### PR TITLE
Allow fetching project ID from GCP application default credentials

### DIFF
--- a/components/veritasai/config/__init__.py
+++ b/components/veritasai/config/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 from dotenv import dotenv_values
+from google import auth
 
 from . import location
 
@@ -10,5 +11,9 @@ if location.is_development:
     env.update(dotenv_values(".env"))
 
 env.update(os.environ)
+
+project_id = env.get("GOOGLE_CLOUD_PROJECT")
+if project_id is None:
+    _, project_id = auth.default()
 
 __all__ = ["env", "location"]

--- a/components/veritasai/pubsub/publisher.py
+++ b/components/veritasai/pubsub/publisher.py
@@ -2,7 +2,7 @@ import json
 from typing import Protocol
 
 from google.cloud.pubsub import PublisherClient
-from veritasai.config import env
+from veritasai.config import project_id
 
 
 class Serializable(Protocol):
@@ -34,7 +34,7 @@ class Publisher:
         """
 
         if project is None:
-            project = env.get("GOOGLE_CLOUD_PROJECT")
+            project = project_id
         if project is None:
             raise ValueError("unknown project ID")
 

--- a/test/components/veritasai/pubsub/test_publisher.py
+++ b/test/components/veritasai/pubsub/test_publisher.py
@@ -2,13 +2,12 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
+from pytest import MonkeyPatch
 from veritasai.pubsub.publisher import Publisher
 
-from development.testsupport import ConfigPatch
 
-
-def test_raises_error_when_project_id_is_undefined(env_var: ConfigPatch):
-    env_var.remove("GOOGLE_CLOUD_PROJECT")
+def test_raises_error_when_project_id_is_undefined(monkeypatch: MonkeyPatch):
+    monkeypatch.setattr("veritasai.pubsub.publisher.project_id", None)
 
     with pytest.raises(ValueError):
         Publisher("topic")


### PR DESCRIPTION
Ensures the Google Cloud Project ID can be determined and/or overridden regardless of runtime environment. It can either be explicitly specified using the `GOOGLE_CLOUD_PROJECT` environment variable or via the GCP application default credentials.