### PR TITLE
Respond with cache status and article id from analysis manager

### DIFF
--- a/bases/veritasai/analysis_manager/handler.py
+++ b/bases/veritasai/analysis_manager/handler.py
@@ -21,10 +21,8 @@ def handler(request: Request) -> typing.ResponseReturnValue:
 
     article = Article.from_input(body.content, body.author, body.publisher, body.source_url)
 
-    if has_article(article.id):
-        # TODO: return a response indicating that the document has already been processed
-        return "", 204
+    cached = has_article(article.id)
+    if not cached:
+        analysis_requests.publish(article)
 
-    analysis_requests.publish(article)
-
-    return "", 204
+    return {"id": article.id, "cached": cached}


### PR DESCRIPTION
Send a meaningful response back from the analysis manager. The response is sent as JSON in the following format:

```jsonc
{
  // The unique ID of the article (string)
  "id": "CZxKAO8iqkW7jhopZVOemND3spFc68tgd9XFmSQk1MI=",
  // Whether the article has already been processed or is being processed (boolean)
  "cached": False,
}
```