### PR TITLE
Send authorization token along with analysis manager request

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ ARTICLES_BUCKET=some-bucket-name
 
 # The topic to publish article analysis requests to
 ANALYSIS_REQUESTS_TOPIC=analysis-requests
+
+# The origin to allow CORS requests from
+# When set to *, all origins are allowed
+CORS_ORIGIN=*

--- a/bases/veritasai/analysis_manager/handler.py
+++ b/bases/veritasai/analysis_manager/handler.py
@@ -2,11 +2,13 @@ import functions_framework
 from flask import Request, typing
 from veritasai.articles import Article
 from veritasai.cache import has_article
+from veritasai.cors import handle_cors
 from veritasai.input_validation import AnalyzeText, ValidationError, response_from_validation_error
 from veritasai.pubsub import analysis_requests
 
 
 @functions_framework.http
+@handle_cors
 def handler(request: Request) -> typing.ResponseReturnValue:
     """
     Initiate the analysis process for a document.

--- a/components/veritasai/cors/__init__.py
+++ b/components/veritasai/cors/__init__.py
@@ -1,0 +1,3 @@
+from .decorator import handle_cors
+
+__all__ = ["handle_cors"]

--- a/components/veritasai/cors/decorator.py
+++ b/components/veritasai/cors/decorator.py
@@ -1,0 +1,28 @@
+import functools
+from typing import Callable
+
+from flask import Request, make_response, typing
+
+from .response import add_cors_headers, cors_response
+
+
+def handle_cors(
+    func: Callable[[Request], typing.ResponseReturnValue],
+) -> Callable[[Request], typing.ResponseReturnValue]:
+    """
+    Wrap a function to handle CORS requests.
+
+    :param func: the function to wrap
+    :return: the wrapped function
+    """
+
+    @functools.wraps(func)
+    def wrapper(request: Request) -> typing.ResponseReturnValue:
+        if request.method == "OPTIONS":
+            return cors_response(request)
+
+        response = make_response(func(request))
+        add_cors_headers(response, request)
+        return response
+
+    return wrapper

--- a/components/veritasai/cors/response.py
+++ b/components/veritasai/cors/response.py
@@ -1,0 +1,53 @@
+from flask import Request, Response
+from veritasai.config import env
+
+ORIGIN = env.get("CORS_ORIGIN", "*")
+
+
+def cors_response(request: Request) -> Response:
+    """
+    Create a CORS response for the given request.
+
+    :param request: the incoming request
+    :return: the CORS response
+    """
+    response = Response(status=204)
+    add_cors_headers(response, request)
+
+    return response
+
+
+def add_cors_headers(response: Response, request: Request):
+    """
+    Add CORS headers to the given response.
+
+    Modifies the response headers in-place.
+
+    :param response: the response to modify
+    :param request: the incoming request
+    """
+
+    origin = allowed_origin(request)
+    if origin is None:
+        return
+
+    response.headers["Access-Control-Allow-Origin"] = origin
+    response.headers["Access-Control-Allow-Methods"] = "POST, OPTIONS"
+    response.headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type"
+    response.headers["Access-Control-Allow-Credentials"] = "true"
+
+
+def allowed_origin(request: Request) -> str | None:
+    """
+    Determine the allowed origin.
+
+    Uses the CORS_ORIGIN environment variable when available, otherwise defaults to the request's
+    origin.
+
+    :param request: the incoming request
+    :return: the allowed origin
+    """
+    if ORIGIN == "*":
+        return request.headers.get("Origin")
+
+    return ORIGIN

--- a/frontend/html/home.html
+++ b/frontend/html/home.html
@@ -40,14 +40,15 @@
 
       <h2 class="text-slate-500 text-xl mb-2">Reveal the Truth</h2>
 
-      <form class="flex flex-col justify-center items-center" method="post">
+      <form id="form" class="flex flex-col justify-center items-center">
         <textarea
           type="text"
-          name="text-to-analyze"
-          id="text-to-analyze"
+          name="content"
+          id="content"
           placeholder="Paste text here"
           rows="6"
           class="block rounded-lg border lg:max-w-96 w-full max-w-64 placeholder-slate-600 text-slate-600 focus:ring-primary border-primary"
+          required
         ></textarea>
         <div class="lg:max-w-96 w-full max-w-64 flex items-center">
           <svg
@@ -122,23 +123,24 @@
             <path d="M20.2 20.2l1.8 1.8" />
           </svg>
           <input
-            type="text"
+            type="url"
             name="source-url"
             id="source-url"
             placeholder="URL"
             class="block w-full rounded-lg border placeholder-slate-600 text-slate-600 focus:ring-primary border-primary"
           />
         </div>
-        <a
+        <button
+          type="submit"
           class="group shadow-md hover:shadow-primary rounded-lg text-4xl py-2 px-4 text-white hover:bg-secondary bg-primary"
-          href="../html/summary.html?uid=demo"
         >
           Analyze
-        </a>
+        </button>
       </form>
     </div>
     <footer id="footer-placeholder"></footer>
 
-    <script type="module" src="/frontend/scripts/nav-bar-logic.js"></script>
+    <script type="module" src="../scripts/home.js"></script>
+    <script type="module" src="../scripts/nav-bar-logic.js"></script>
   </body>
 </html>

--- a/frontend/scripts/home.js
+++ b/frontend/scripts/home.js
@@ -1,6 +1,11 @@
+import { currentUser } from './user.js';
+
 const BACKEND_URL = 'http://localhost:5000';
 
 const form = document.getElementById('form');
+
+const user = await currentUser;
+if (user === null) window.location.href = 'login.html';
 
 form.addEventListener('submit', async (event) => {
   event.preventDefault();
@@ -12,7 +17,10 @@ form.addEventListener('submit', async (event) => {
 
   const response = await fetch(BACKEND_URL, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${await user.getIdToken()}`,
+    },
     body: JSON.stringify(data),
   });
   if (!response.ok) {

--- a/frontend/scripts/home.js
+++ b/frontend/scripts/home.js
@@ -1,0 +1,27 @@
+const BACKEND_URL = 'http://localhost:5000';
+
+const form = document.getElementById('form');
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+
+  const data = Object.fromEntries(new FormData(form));
+  for (const key in data) if (data[key].trim().length === 0) delete data[key];
+
+  // TODO: show loading spinner
+
+  const response = await fetch(BACKEND_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    // TODO: handle errors properly
+    const message = await response.text();
+    console.error(message);
+    return;
+  }
+
+  const result = await response.json();
+  window.location.href = `summary.html?uid=${result.id}`;
+});

--- a/projects/analysis-manager/pyproject.toml
+++ b/projects/analysis-manager/pyproject.toml
@@ -27,6 +27,7 @@ includes = ["main.py", "requirements.txt"]
 "../../components/veritasai/articles" = "veritasai/articles"
 "../../components/veritasai/cache" = "veritasai/cache"
 "../../components/veritasai/config" = "veritasai/config"
+"../../components/veritasai/cors" = "veritasai/cors"
 "../../components/veritasai/firebase" = "veritasai/firebase"
 "../../components/veritasai/input_validation" = "veritasai/input_validation"
 "../../components/veritasai/pubsub" = "veritasai/pubsub"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ analysis-manager.env = { PORT = "8080" }
 "components/veritasai/articles" = "veritasai/articles"
 "components/veritasai/cache" = "veritasai/cache"
 "components/veritasai/config" = "veritasai/config"
+"components/veritasai/cors" = "veritasai/cors"
 "components/veritasai/firebase" = "veritasai/firebase"
 "components/veritasai/input_validation" = "veritasai/input_validation"
 "components/veritasai/protocol" = "veritasai/protocol"

--- a/test/components/veritasai/cors/test_add_cors_headers.py
+++ b/test/components/veritasai/cors/test_add_cors_headers.py
@@ -1,0 +1,54 @@
+from flask import Request, Response
+from pytest import MonkeyPatch
+from veritasai.cors.response import add_cors_headers
+
+
+def test_adds_headers_when_origin_statically_configured(monkeypatch: MonkeyPatch):
+    monkeypatch.setattr("veritasai.cors.response.ORIGIN", "http://configured.com")
+    request = Request.from_values(method="OPTIONS")
+
+    response = Response()
+    add_cors_headers(response, request)
+
+    assert response.headers["Access-Control-Allow-Origin"] == "http://configured.com"
+    assert response.headers["Access-Control-Allow-Methods"] == "POST, OPTIONS"
+    assert response.headers["Access-Control-Allow-Headers"] == "Authorization, Content-Type"
+    assert response.headers["Access-Control-Allow-Credentials"] == "true"
+
+
+def test_allow_origin_header_does_not_match_request_origin_when_explicitly_configured(
+    monkeypatch: MonkeyPatch,
+):
+    monkeypatch.setattr("veritasai.cors.response.ORIGIN", "http://configured.com")
+    request = Request.from_values(method="OPTIONS", headers={"Origin": "http://example.com"})
+
+    response = Response()
+    add_cors_headers(response, request)
+
+    assert response.headers["Access-Control-Allow-Origin"] == "http://configured.com"
+
+
+def test_adds_headers_when_origin_set_to_mirror_request(monkeypatch: MonkeyPatch):
+    monkeypatch.setattr("veritasai.cors.response.ORIGIN", "*")
+    request = Request.from_values(method="OPTIONS", headers={"Origin": "http://example.com"})
+
+    response = Response()
+    add_cors_headers(response, request)
+
+    assert response.headers["Access-Control-Allow-Origin"] == "http://example.com"
+    assert response.headers["Access-Control-Allow-Methods"] == "POST, OPTIONS"
+    assert response.headers["Access-Control-Allow-Headers"] == "Authorization, Content-Type"
+    assert response.headers["Access-Control-Allow-Credentials"] == "true"
+
+
+def test_does_not_add_headers_when_origin_set_to_mirror_and_no_origin_header_present(
+    monkeypatch: MonkeyPatch,
+):
+    monkeypatch.setattr("veritasai.cors.response.ORIGIN", "*")
+    request = Request.from_values(method="OPTIONS")
+
+    response = Response()
+    add_cors_headers(response, request)
+
+    for header in response.headers.keys():
+        assert not header.startswith("Access-Control-")

--- a/test/components/veritasai/cors/test_allowed_origin.py
+++ b/test/components/veritasai/cors/test_allowed_origin.py
@@ -1,0 +1,21 @@
+from flask import Request
+from pytest import MonkeyPatch
+from veritasai.cors.response import allowed_origin
+
+
+def test_mirrors_request_origin_when_set_to_astrisk(monkeypatch: MonkeyPatch):
+    monkeypatch.setattr("veritasai.cors.response.ORIGIN", "*")
+    request = Request.from_values(method="OPTIONS", headers={"Origin": "http://example.com"})
+    assert allowed_origin(request) == "http://example.com"
+
+
+def test_returns_configured_origin_when_set_to_specific_origin(monkeypatch: MonkeyPatch):
+    monkeypatch.setattr("veritasai.cors.response.ORIGIN", "http://configured.com")
+    request = Request.from_values(method="OPTIONS", headers={"Origin": "http://example.com"})
+    assert allowed_origin(request) == "http://configured.com"
+
+
+def test_returns_none_when_not_explicitly_configured_and_no_origin_header(monkeypatch: MonkeyPatch):
+    monkeypatch.setattr("veritasai.cors.response.ORIGIN", "*")
+    request = Request.from_values(method="OPTIONS")
+    assert allowed_origin(request) is None

--- a/test/components/veritasai/cors/test_decorator.py
+++ b/test/components/veritasai/cors/test_decorator.py
@@ -1,0 +1,88 @@
+from typing import Generator
+
+import pytest
+from flask import Flask, Request, Response, typing
+from pytest import MonkeyPatch
+from veritasai.cors import handle_cors
+
+
+@handle_cors
+def dummy_handler(_request: Request) -> typing.ResponseReturnValue:
+    """
+    A dummy handler for testing purposes.
+
+    :param _request: the incoming request
+    :return: an empty successful response
+    """
+    return Response(status=204)
+
+
+@pytest.fixture(autouse=True)
+def app_context() -> Generator[Flask, None, None]:
+    """
+    Create a dummy Flask app context for testing.
+    """
+    flask = Flask(__name__)
+    with flask.test_request_context():
+        yield flask
+
+
+def test_passes_through_request_when_non_options_method_and_no_origin_header():
+    response = dummy_handler(Request.from_values(method="GET"))
+
+    assert response.status_code == 204
+
+    for header in response.headers.keys():
+        assert not header.startswith("Access-Control-")
+
+
+def test_passes_through_request_when_non_options_method_and_origin_header_present():
+    response = dummy_handler(
+        Request.from_values(method="GET", headers={"Origin": "http://example.com"})
+    )
+
+    assert response.status_code == 204
+    assert response.headers["Access-Control-Allow-Origin"] == "http://example.com"
+    assert response.headers["Access-Control-Allow-Methods"] == "POST, OPTIONS"
+    assert response.headers["Access-Control-Allow-Headers"] == "Authorization, Content-Type"
+    assert response.headers["Access-Control-Allow-Credentials"] == "true"
+
+
+def test_resonds_with_cors_headers_when_options_method_and_origin_explicitly_configured(
+    monkeypatch: MonkeyPatch,
+):
+    monkeypatch.setattr("veritasai.cors.response.ORIGIN", "http://configured.com")
+    response = dummy_handler(Request.from_values(method="OPTIONS", headers={}))
+
+    assert response.status_code == 204
+    assert response.headers["Access-Control-Allow-Origin"] == "http://configured.com"
+    assert response.headers["Access-Control-Allow-Methods"] == "POST, OPTIONS"
+    assert response.headers["Access-Control-Allow-Headers"] == "Authorization, Content-Type"
+    assert response.headers["Access-Control-Allow-Credentials"] == "true"
+
+
+def test_resonds_with_cors_headers_when_options_method_and_origin_configured_to_mirror(
+    monkeypatch: MonkeyPatch,
+):
+    monkeypatch.setattr("veritasai.cors.response.ORIGIN", "*")
+    response = dummy_handler(
+        Request.from_values(method="OPTIONS", headers={"Origin": "http://example.com"})
+    )
+
+    assert response.status_code == 204
+    assert response.headers["Access-Control-Allow-Origin"] == "http://example.com"
+    assert response.headers["Access-Control-Allow-Methods"] == "POST, OPTIONS"
+    assert response.headers["Access-Control-Allow-Headers"] == "Authorization, Content-Type"
+    assert response.headers["Access-Control-Allow-Credentials"] == "true"
+
+
+def test_omits_cors_headers_when_options_method_and_no_origin_header_present(
+    monkeypatch: MonkeyPatch,
+):
+    monkeypatch.setattr("veritasai.cors.response.ORIGIN", "*")
+    response = dummy_handler(Request.from_values(method="OPTIONS"))
+
+    assert response.status_code == 204
+
+    for header in response.headers.keys():
+        assert not header.startswith("Access-Control-")


### PR DESCRIPTION
Adds sending requests to the analysis manager from the frontend along with the user's Firebase ID token. Also adds CORS headers to the analysis manager responses to ensure compatible with the browser.