### PR TITLE
Require Firebase ID tokens in requests to the analysis manager

### DIFF
--- a/bases/veritasai/analysis_manager/handler.py
+++ b/bases/veritasai/analysis_manager/handler.py
@@ -1,6 +1,7 @@
 import functions_framework
 from flask import Request, typing
 from veritasai.articles import Article
+from veritasai.authentication import login_required
 from veritasai.cache import has_article
 from veritasai.cors import handle_cors
 from veritasai.input_validation import AnalyzeText, ValidationError, response_from_validation_error
@@ -9,6 +10,7 @@ from veritasai.pubsub import analysis_requests
 
 @functions_framework.http
 @handle_cors
+@login_required
 def handler(request: Request) -> typing.ResponseReturnValue:
     """
     Initiate the analysis process for a document.

--- a/components/veritasai/authentication/__init__.py
+++ b/components/veritasai/authentication/__init__.py
@@ -1,0 +1,3 @@
+from .decorator import login_required
+
+__all__ = ["login_required"]

--- a/components/veritasai/authentication/decorator.py
+++ b/components/veritasai/authentication/decorator.py
@@ -1,0 +1,28 @@
+import functools
+from typing import Callable
+
+from firebase_admin.auth import InvalidIdTokenError
+from flask import Request, make_response, typing
+from veritasai.firebase import get_auth
+
+
+def login_required(
+    func: Callable[[Request], typing.ResponseReturnValue],
+) -> Callable[[Request], typing.ResponseReturnValue]:
+    """
+    Decorator to require a user to be logged in.
+    """
+
+    @functools.wraps(func)
+    def wrapper(request: Request) -> typing.ResponseReturnValue:
+        if request.authorization is None or request.authorization.type.lower() != "bearer":
+            return make_response({"error": "bearer token required"}, 401)
+
+        try:
+            get_auth().verify_id_token(request.authorization.token)
+        except InvalidIdTokenError:
+            return make_response({"error": "invalid bearer token"}, 401)
+
+        return func(request)
+
+    return wrapper

--- a/components/veritasai/firebase/__init__.py
+++ b/components/veritasai/firebase/__init__.py
@@ -1,38 +1,21 @@
-import firebase_admin
-from dotenv import load_dotenv
-from firebase_admin import firestore
-from firebase_admin.credentials import ApplicationDefault, Base, Certificate
+from firebase_admin import auth, firestore
 from google.cloud.firestore import Client
-from veritasai.config import env
 
-load_dotenv()
+from .app import init_app
 
 
-def _get_credentials() -> Base:
+def get_auth() -> auth.Client:
     """
-    Get the credentials for the Firebase Admin SDK.
+    Get the Firebase Authentication client
     """
-    credentials = ApplicationDefault()
-
-    if (service_account := env.get("FIREBASE_SERVICE_ACCOUNT")) is not None:
-        credentials = Certificate(service_account)
-
-    return credentials
-
-
-_app = None
+    return auth.Client(app=init_app())
 
 
 def get_db() -> Client:
     """
     Get the Firestore client.
     """
-    global _app
-
-    if _app is None:
-        _app = firebase_admin.initialize_app(credential=_get_credentials())
-
-    return firestore.client(app=_app)
+    return firestore.client(app=init_app())
 
 
-__all__ = ["get_db"]
+__all__ = ["get_auth", "get_db", "init_app"]

--- a/components/veritasai/firebase/app.py
+++ b/components/veritasai/firebase/app.py
@@ -1,0 +1,31 @@
+import firebase_admin
+from firebase_admin import App
+from firebase_admin.credentials import ApplicationDefault, Base, Certificate
+from veritasai.config import env
+
+
+def _get_credentials() -> Base:
+    """
+    Get the credentials for the Firebase Admin SDK.
+    """
+    credentials = ApplicationDefault()
+
+    if (service_account := env.get("FIREBASE_SERVICE_ACCOUNT")) is not None:
+        credentials = Certificate(service_account)
+
+    return credentials
+
+
+_app = None
+
+
+def init_app() -> App:
+    """
+    Initialize the Firebase Admin SDK.
+    """
+    global _app
+
+    if _app is None:
+        _app = firebase_admin.initialize_app(credential=_get_credentials())
+
+    return _app

--- a/projects/analysis-manager/pyproject.toml
+++ b/projects/analysis-manager/pyproject.toml
@@ -25,6 +25,7 @@ includes = ["main.py", "requirements.txt"]
 [tool.polylith.bricks]
 "../../bases/veritasai/analysis_manager" = "veritasai/analysis_manager"
 "../../components/veritasai/articles" = "veritasai/articles"
+"../../components/veritasai/authentication" = "veritasai/authentication"
 "../../components/veritasai/cache" = "veritasai/cache"
 "../../components/veritasai/config" = "veritasai/config"
 "../../components/veritasai/cors" = "veritasai/cors"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ analysis-manager.env = { PORT = "8080" }
 [tool.polylith.bricks]
 "bases/veritasai/analysis_manager" = "veritasai/analysis_manager"
 "components/veritasai/articles" = "veritasai/articles"
+"components/veritasai/authentication" = "veritasai/authentication"
 "components/veritasai/cache" = "veritasai/cache"
 "components/veritasai/config" = "veritasai/config"
 "components/veritasai/cors" = "veritasai/cors"

--- a/test/bases/veritasai/analysis_manager/test_validation.py
+++ b/test/bases/veritasai/analysis_manager/test_validation.py
@@ -1,7 +1,16 @@
 import pytest
 from flask.testing import FlaskClient
+from pytest import MonkeyPatch
 
 pytestmark = pytest.mark.function("analysis_manager")
+
+
+@pytest.fixture(autouse=True)
+def disable_authentication(monkeypatch: MonkeyPatch):
+    """
+    Disable authentication for testing purposes.
+    """
+    monkeypatch.setattr("veritasai.authentication.login_required", lambda func: func)
 
 
 @pytest.fixture

--- a/test/components/veritasai/authentication/test_decorator.py
+++ b/test/components/veritasai/authentication/test_decorator.py
@@ -1,0 +1,62 @@
+from typing import Generator
+
+import pytest
+from firebase_admin.auth import InvalidIdTokenError
+from flask import Flask, Request, Response, typing
+from pytest_mock import MockerFixture
+from veritasai.authentication import login_required
+
+
+@login_required
+def dummy_handler(_request: Request) -> typing.ResponseReturnValue:
+    """
+    A dummy handler for testing purposes.
+
+    :param _request: the incoming request
+    :return: an empty successful response
+    """
+    return Response(status=204)
+
+
+@pytest.fixture(autouse=True)
+def app_context() -> Generator[Flask, None, None]:
+    """
+    Create a dummy Flask app context for testing.
+    """
+    flask = Flask(__name__)
+    with flask.test_request_context():
+        yield flask
+
+
+def test_returns_error_when_no_token():
+    response = dummy_handler(Request.from_values())
+
+    assert response.status_code == 401
+    assert response.json == {"error": "bearer token required"}
+
+
+def test_returns_error_when_authorization_header_is_not_bearer():
+    response = dummy_handler(Request.from_values(headers={"Authorization": "Basic test"}))
+
+    assert response.status_code == 401
+    assert response.json == {"error": "bearer token required"}
+
+
+def test_returns_error_when_token_is_invalid(mocker: MockerFixture):
+    auth = mocker.patch("veritasai.authentication.decorator.get_auth")
+    auth.return_value.verify_id_token.side_effect = InvalidIdTokenError("invalid token")
+
+    response = dummy_handler(Request.from_values(headers={"Authorization": "Bearer invalid"}))
+
+    assert response.status_code == 401
+    assert response.json == {"error": "invalid bearer token"}
+
+
+def test_passes_through_when_token_is_valid(mocker: MockerFixture):
+    auth = mocker.patch("veritasai.authentication.decorator.get_auth")
+    auth.return_value.verify_id_token.return_value = {}
+
+    response = dummy_handler(Request.from_values(headers={"Authorization": "Bearer valid"}))
+
+    assert response.status_code == 204
+    assert response.json is None

--- a/test/components/veritasai/firebase/test_credentials.py
+++ b/test/components/veritasai/firebase/test_credentials.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from firebase_admin.credentials import ApplicationDefault, Certificate
-from veritasai.firebase import _get_credentials
+from veritasai.firebase.app import _get_credentials
 
 from development.testsupport import ConfigPatch
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -81,10 +81,7 @@ def disable_firebase_admin_sdk_initialization(monkeypatch: MonkeyPatch):
 
     This ensures that credentials are not required to run tests.
     """
-    with monkeypatch.context() as m:
-        m.setattr("firebase_admin.initialize_app", lambda *args, **kwargs: None)
-
-        yield
+    monkeypatch.setattr("veritasai.firebase.init_app", lambda: None)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Requires Firebase ID tokens be sent along with requests to the analysis manager. The tokens must be sent in the `Authorization` header with the bearer type.