### PR TITLE
Integrate backend with Google Cloud Logging

### DIFF
--- a/bases/veritasai/analysis_manager/handler.py
+++ b/bases/veritasai/analysis_manager/handler.py
@@ -5,7 +5,10 @@ from veritasai.authentication import login_required
 from veritasai.cache import has_article
 from veritasai.cors import handle_cors
 from veritasai.input_validation import AnalyzeText, ValidationError, response_from_validation_error
+from veritasai.logging import get_logger
 from veritasai.pubsub import analysis_requests
+
+logger = get_logger("veritasai.analysis_manager")
 
 
 @functions_framework.http
@@ -26,6 +29,9 @@ def handler(request: Request) -> typing.ResponseReturnValue:
     article = Article.from_input(body.content, body.author, body.publisher, body.source_url)
 
     cached = has_article(article.id)
+
+    logger.info("Received article %(id)s for analysis", {"id": article.id, "cached": cached})
+
     if not cached:
         analysis_requests.publish(article)
 

--- a/components/veritasai/authentication/decorator.py
+++ b/components/veritasai/authentication/decorator.py
@@ -4,6 +4,9 @@ from typing import Callable
 from firebase_admin.auth import InvalidIdTokenError
 from flask import Request, make_response, typing
 from veritasai.firebase import get_auth
+from veritasai.logging import get_logger
+
+logger = get_logger("veritasai.authentication.decorator")
 
 
 def login_required(
@@ -19,10 +22,11 @@ def login_required(
             return make_response({"error": "bearer token required"}, 401)
 
         try:
-            get_auth().verify_id_token(request.authorization.token)
+            request.user = get_auth().verify_id_token(request.authorization.token)
         except InvalidIdTokenError:
             return make_response({"error": "invalid bearer token"}, 401)
 
+        logger.info("User %(sub)s authenticated", {"sub": request.user["sub"]})
         return func(request)
 
     return wrapper

--- a/components/veritasai/cors/decorator.py
+++ b/components/veritasai/cors/decorator.py
@@ -2,8 +2,11 @@ import functools
 from typing import Callable
 
 from flask import Request, make_response, typing
+from veritasai.logging import get_logger
 
 from .response import add_cors_headers, cors_response
+
+logger = get_logger("veritasai.cors.decorator")
 
 
 def handle_cors(
@@ -19,6 +22,7 @@ def handle_cors(
     @functools.wraps(func)
     def wrapper(request: Request) -> typing.ResponseReturnValue:
         if request.method == "OPTIONS":
+            logger.info("Handling CORS preflight request")
             return cors_response(request)
 
         response = make_response(func(request))

--- a/components/veritasai/logging/__init__.py
+++ b/components/veritasai/logging/__init__.py
@@ -1,4 +1,4 @@
-from logging import getLogger
+from logging import basicConfig, getLogger
 
 from google.cloud import logging
 from veritasai.config import location
@@ -6,6 +6,8 @@ from veritasai.config import location
 if location.is_production:
     client = logging.Client()
     client.setup_logging()
+elif location.is_development:
+    basicConfig(level="INFO")
 
 get_logger = getLogger
 

--- a/components/veritasai/logging/__init__.py
+++ b/components/veritasai/logging/__init__.py
@@ -1,0 +1,12 @@
+from logging import getLogger
+
+from google.cloud import logging
+from veritasai.config import location
+
+if location.is_production:
+    client = logging.Client()
+    client.setup_logging()
+
+get_logger = getLogger
+
+__all__ = ["get_logger"]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:f5cc7b5fd7fbeb722be6d45a03677def9ef9285b3de58abf36bfc81883acc5b1"
+content_hash = "sha256:57ac06e6396fa85bb7146634e20298f2d9674f3756fa41906151d1e4ee831e49"
 
 [[package]]
 name = "annotated-types"
@@ -417,6 +417,38 @@ files = [
 ]
 
 [[package]]
+name = "google-cloud-appengine-logging"
+version = "1.4.3"
+requires_python = ">=3.7"
+summary = "Google Cloud Appengine Logging API client library"
+groups = ["default"]
+dependencies = [
+    "google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.1",
+    "google-auth!=2.24.0,!=2.25.0,<3.0.0dev,>=2.14.1",
+    "proto-plus<2.0.0dev,>=1.22.3",
+    "protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5",
+]
+files = [
+    {file = "google-cloud-appengine-logging-1.4.3.tar.gz", hash = "sha256:fb504e6199fe8de85baa9d31cecf6776877851fe58867de603317ec7cc739987"},
+    {file = "google_cloud_appengine_logging-1.4.3-py2.py3-none-any.whl", hash = "sha256:8e30af51d853f219caf29e8b8b342b9ce8214b29f334dafae38d39aaaff7d372"},
+]
+
+[[package]]
+name = "google-cloud-audit-log"
+version = "0.2.5"
+requires_python = ">=3.7"
+summary = "Google Cloud Audit Protos"
+groups = ["default"]
+dependencies = [
+    "googleapis-common-protos<2.0dev,>=1.56.2",
+    "protobuf!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5",
+]
+files = [
+    {file = "google-cloud-audit-log-0.2.5.tar.gz", hash = "sha256:86e2faba3383adc8fd04a5bd7fd4f960b3e4aedaa7ed950f2f891ce16902eb6b"},
+    {file = "google_cloud_audit_log-0.2.5-py2.py3-none-any.whl", hash = "sha256:18b94d4579002a450b7902cd2e8b8fdcb1ea2dd4df3b41f8f82be6d9f7fcd746"},
+]
+
+[[package]]
 name = "google-cloud-core"
 version = "2.4.1"
 requires_python = ">=3.7"
@@ -466,6 +498,28 @@ dependencies = [
 files = [
     {file = "google-cloud-language-2.13.3.tar.gz", hash = "sha256:569d35260af906de25b8e2a76b6364e05809b8453afd89da738d4a4fcb90846f"},
     {file = "google_cloud_language-2.13.3-py2.py3-none-any.whl", hash = "sha256:b060de20d8ed2b20b7b7ebd8a46ae240df36c9977db383db5155276d2b1f6b9a"},
+]
+
+[[package]]
+name = "google-cloud-logging"
+version = "3.10.0"
+requires_python = ">=3.7"
+summary = "Stackdriver Logging API client library"
+groups = ["default"]
+dependencies = [
+    "google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.1",
+    "google-auth!=2.24.0,!=2.25.0,<3.0.0dev,>=2.14.1",
+    "google-cloud-appengine-logging<2.0.0dev,>=0.1.0",
+    "google-cloud-audit-log<1.0.0dev,>=0.1.0",
+    "google-cloud-core<3.0.0dev,>=2.0.0",
+    "grpc-google-iam-v1<1.0.0dev,>=0.12.4",
+    "proto-plus<2.0.0dev,>=1.22.0",
+    "proto-plus<2.0.0dev,>=1.22.2; python_version >= \"3.11\"",
+    "protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5",
+]
+files = [
+    {file = "google-cloud-logging-3.10.0.tar.gz", hash = "sha256:d93d347351240ddb14cfe201987a2d32cf9d7f478b8b2fabed3015b425b3274f"},
+    {file = "google_cloud_logging-3.10.0-py2.py3-none-any.whl", hash = "sha256:132192beb45731130a2ffbcd4b2b5cbd87370e7dcfa7397ae4002154f542bd20"},
 ]
 
 [[package]]

--- a/projects/analysis-manager/pyproject.toml
+++ b/projects/analysis-manager/pyproject.toml
@@ -31,4 +31,5 @@ includes = ["main.py", "requirements.txt"]
 "../../components/veritasai/cors" = "veritasai/cors"
 "../../components/veritasai/firebase" = "veritasai/firebase"
 "../../components/veritasai/input_validation" = "veritasai/input_validation"
+"../../components/veritasai/logging" = "veritasai/logging"
 "../../components/veritasai/pubsub" = "veritasai/pubsub"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "firebase-admin>=6.5.0",
   "google-cloud-storage>=2.16.0",
   "google-cloud-pubsub>=2.21.1",
+  "google-cloud-logging>=3.10.0",
 ]
 
 [build-system]
@@ -46,6 +47,7 @@ analysis-manager.env = { PORT = "8080" }
 "components/veritasai/cors" = "veritasai/cors"
 "components/veritasai/firebase" = "veritasai/firebase"
 "components/veritasai/input_validation" = "veritasai/input_validation"
+"components/veritasai/logging" = "veritasai/logging"
 "components/veritasai/protocol" = "veritasai/protocol"
 "components/veritasai/pubsub" = "veritasai/pubsub"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,4 +71,7 @@ line-ending = "auto"
 docstring-code-format = true
 
 [tool.ruff.lint]
-select = ["A", "B", "E4", "E501", "E7", "E9", "F", "I", "N", "RUF"]
+select = ["A", "B", "E4", "E501", "E7", "E9", "F", "G", "I", "LOG", "N", "T20", "RUF"]
+
+[tool.ruff.lint.per-file-ignores]
+"development/**.py" = ["T20"]

--- a/test/components/veritasai/authentication/test_decorator.py
+++ b/test/components/veritasai/authentication/test_decorator.py
@@ -54,7 +54,7 @@ def test_returns_error_when_token_is_invalid(mocker: MockerFixture):
 
 def test_passes_through_when_token_is_valid(mocker: MockerFixture):
     auth = mocker.patch("veritasai.authentication.decorator.get_auth")
-    auth.return_value.verify_id_token.return_value = {}
+    auth.return_value.verify_id_token.return_value = {"sub": "user-id"}
 
     response = dummy_handler(Request.from_values(headers={"Authorization": "Bearer valid"}))
 


### PR DESCRIPTION
Creates a component to handle Python logging configuration. In production, logs are automatically sent to Cloud Logging, however, in development they are just sent to stdout. No logs are emitted in tests.

The logging component was also integrated into the analysis manager base, cors, and authentication bricks to provide additional information for debugging.