### PR TITLE
Only look for changes in pyproject.toml files in polylith checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,7 +65,7 @@ jobs:
       - run: |
           pdm run poly sync
 
-          if ! git diff --quiet HEAD; then
+          if ! find . -name pyproject.toml -print0 | xargs -0 git diff --exit-code HEAD; then
             echo "not all bricks are in sync, please run 'pdm run poly sync' and commit the changes."
             exit 1
           fi


### PR DESCRIPTION
Fixes the Polylith check accidentally discovering changes in other files due to blanket `git diff`. This was resolved by only looking at `pyproject.toml` files in the `git diff`. The quiet flag on the diff was also removed in favor of exit code to give more information if something like this should happen again.