### PR TITLE
Create development tool for interactively testing pubsub handlers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,7 @@
       "env": {
         "FLASK_APP": "development/function.py",
         "FLASK_DEBUG": "1",
+        "FLASK_RUN_PORT": "8000",
         "FUNCTION": "analysis_manager"
       },
       "args": ["run", "--no-debugger"],
@@ -25,6 +26,7 @@
       "env": {
         "FLASK_APP": "development/function.py",
         "FLASK_DEBUG": "1",
+        "FLASK_RUN_PORT": "8001",
         "FUNCTION": "tone_analyzer"
       },
       "args": ["run", "--no-debugger"],

--- a/development/publish.py
+++ b/development/publish.py
@@ -57,7 +57,7 @@ from veritasai.articles import Article
         "--port",
         "-p",
         help="The port the development server is running on",
-        default=5000,
+        default=8000,
         metavar="PORT",
         type=cloup.INT,
         show_default=True,

--- a/development/publish.py
+++ b/development/publish.py
@@ -1,0 +1,124 @@
+import json
+from base64 import b64encode
+from datetime import datetime, timezone
+
+import click
+import cloup
+import requests
+from cloup.constraints import mutually_exclusive
+from veritasai.articles import Article
+
+
+@cloup.command()
+@cloup.option_group(
+    "Sources",
+    cloup.option("--content", "-c", help="The content to send to", type=cloup.STRING),
+    cloup.option(
+        "--file", "-f", help="The file containing the content to send", type=cloup.File("r")
+    ),
+    cloup.option(
+        "--id", "-i", "article_id", help="The article ID to send", metavar="ID", type=cloup.STRING
+    ),
+    constraint=mutually_exclusive,
+)
+@cloup.option_group(
+    "Article metadata",
+    cloup.option(
+        "--author",
+        help="The name of the article's author",
+        metavar="AUTHOR",
+        type=cloup.STRING,
+    ),
+    cloup.option(
+        "--publisher",
+        help="The name of the article's publisher",
+        metavar="PUBLISHER",
+        type=cloup.STRING,
+    ),
+    cloup.option(
+        "--url",
+        help="The URL where the article can be found",
+        metavar="URL",
+        type=cloup.STRING,
+    ),
+)
+@cloup.option_group(
+    "Development server",
+    cloup.option(
+        "--address",
+        "-a",
+        help="The address the development server is running on",
+        default="127.0.0.1",
+        metavar="ADDRESS",
+        type=cloup.STRING,
+        show_default=True,
+    ),
+    cloup.option(
+        "--port",
+        "-p",
+        help="The port the development server is running on",
+        default=5000,
+        metavar="PORT",
+        type=cloup.INT,
+        show_default=True,
+    ),
+)
+def publish(
+    address: str,
+    port: int,
+    content: str | None = None,
+    file: cloup.File | None = None,
+    article_id: str | None = None,
+    author: str | None = None,
+    publisher: str | None = None,
+    url: str | None = None,
+):
+    """
+    Mock a Pub/Sub publish operation for analysis requests.
+
+    The article content can be provided as a string, a file, or an already existing article ID.
+    """
+
+    if file is not None:
+        content = file.read()
+    if content is not None:
+        article = Article.from_input(content, author=author, publisher=publisher, url=url)
+    else:
+        article = Article(id=article_id, author=author, publisher=publisher, url=url)
+
+    serialized = json.dumps(article.to_dict()).encode("utf-8")
+    encoded = b64encode(serialized).decode()
+
+    response = requests.post(
+        f"http://{address}:{port}/",
+        json={
+            "message": {
+                "data": encoded,
+            }
+        },
+        headers={
+            "Content-Type": "application/json",
+            "ce-id": "123451234512345",
+            "ce-specversion": "1.0",
+            "ce-time": datetime.now(timezone.utc).isoformat(),
+            "ce-type": "google.cloud.pubsub.topic.v1.messagePublished",
+            "ce-source": "//pubsub.googleapis.com/projects//topics//",
+        },
+    )
+
+    click.secho("Status: ", fg="yellow", nl=False)
+
+    if response.ok:
+        click.secho("OK", fg="green")
+    else:
+        click.secho("ERROR", fg="red")
+
+        click.secho("Status code: ", fg="yellow", nl=False)
+        click.secho(str(response.status_code), fg="red")
+
+        click.secho("Response:", fg="yellow")
+        click.echo(response.text)
+
+
+if __name__ == "__main__":
+    publish()

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:c884e95eef8762998ddb8f55b02593754da8e886aeacec14bfa6380aa3575bff"
+content_hash = "sha256:6851e19b24f3739930cbc17b9eb8c93a16ffc0523198f77ccd569e6c24f24297"
 
 [[package]]
 name = "annotated-types"
@@ -196,12 +196,26 @@ files = [
 ]
 
 [[package]]
+name = "cloup"
+version = "3.0.5"
+requires_python = ">=3.7"
+summary = "Adds features to Click: option groups, constraints, subcommand sections and help themes."
+groups = ["default"]
+dependencies = [
+    "click<9.0,>=8.0",
+]
+files = [
+    {file = "cloup-3.0.5-py2.py3-none-any.whl", hash = "sha256:bf122036066584eb0db113561167c29969cc015972b7b7ee03158d9bc7de87f8"},
+    {file = "cloup-3.0.5.tar.gz", hash = "sha256:c92b261c7bb7e13004930f3fb4b3edad8de2d1f12994dcddbe05bc21990443c5"},
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
 groups = ["default", "dev"]
-marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
+marker = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
   "ibm-cloud-sdk-core>=3.20.0",
   "google-cloud-pubsub>=2.21.1",
   "google-cloud-logging>=3.10.0",
+  "click>=8.1.7",
+  "cloup>=3.0.5",
+  "requests>=2.32.2",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,9 @@ format = { cmd = "ruff format --check" }
 test = { cmd = "pytest" }
 
 analysis-manager.cmd = "functions-framework --target=handler --source projects/analysis-manager/main.py"
-analysis-manager.env = { PORT = "8080" }
+analysis-manager.env = { PORT = "8000" }
+tone-analyzer.cmd = "functions-framework --target=handler --source projects/tone-analyzer/main.py"
+tone-analyzer.env = { PORT = "8001" }
 
 [tool.polylith.bricks]
 "bases/veritasai/analysis_manager" = "veritasai/analysis_manager"


### PR DESCRIPTION
Adds a development script for interactively testing Pub/Sub handlers. The script can source content from an existing article ID, from a string, or a file. Additional metadata such as the author name, publisher name, and the URL.

```shell
python3 development/publish.py --help
Usage: publish.py [OPTIONS]

  Mock a Pub/Sub publish operation for analysis requests.

  The article content can be provided as a string, a file, or an already
  existing article ID.

Sources: [mutually exclusive]
  -c, --content TEXT     The content to send to
  -f, --file FILENAME    The file containing the content to send
  -i, --id ID            The article ID to send

Article metadata:
  --author AUTHOR        The name of the article's author
  --publisher PUBLISHER  The name of the article's publisher
  --url URL              The URL where the article can be found

Development server:
  -a, --address ADDRESS  The address the development server is running on
                         [default: 127.0.0.1]
  -p, --port PORT        The port the development server is running on
                         [default: 8000]

Other options:
  --help                 Show this message and exit.
```