### PR TITLE
Bump available memory for analyzers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,6 +149,7 @@ jobs:
             --entry-point=handler \
             --trigger-topic=${TOPIC} \
             --env-vars-file=env.yaml \
+            --memory=512Mb \
             --timeout=300s \
             --ingress-settings=internal-only \
             --ignore-file=$(pwd)/.gcloudignore


### PR DESCRIPTION
Some analyzers were running out of memory after multiple requests were processed. This alleviates this problem by doubling their available memory.